### PR TITLE
ci(release): switch publish to npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,14 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm run build
-      # Bootstrap publish auth: NODE_AUTH_TOKEN (Classic Automation token).
-      # @salishforge/memforge does not exist on npm yet, so Trusted Publishing
-      # cannot be configured for it — trusted publishers are attached to an
-      # existing package on npmjs.com. After the first publish succeeds, swap
-      # this step to OIDC by removing NODE_AUTH_TOKEN (id-token: write is
-      # already granted for provenance attestations).
+      # Auth via npm Trusted Publishing (OIDC). The package exists on npm
+      # as of v3.0.0-beta.3, so a trusted publisher can be configured for
+      # it on npmjs.com (Packages → @salishforge/memforge → Settings →
+      # Trusted publishing). Once configured, no NODE_AUTH_TOKEN is needed:
+      # npm CLI uses the GitHub Actions OIDC token (id-token: write, above)
+      # to authenticate directly.
       - name: Publish package
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Summary

Removes \`NODE_AUTH_TOKEN\` from the publish step so \`npm publish\` authenticates via the GitHub Actions OIDC token. The \`id-token: write\` permission was already granted for provenance attestations; Trusted Publishing reuses that same OIDC token.

## Prerequisite (one-time, on npm.com)

Before merging this PR, a trusted publisher must be configured for \`@salishforge/memforge\`:

1. https://www.npmjs.com/package/@salishforge/memforge/access → **Trusted publishers** → **Add**
2. Publisher type: **GitHub Actions**
3. Organization: \`salishforge\` · Repository: \`memforge\` · Workflow filename: \`release.yml\` · Environment: (blank)

If this is not configured before merging, the **next** release tag will fail to publish (beta.3 is already shipped so nothing is at risk until beta.4).

## Why

- No token to rotate or leak; no 2FA bypass flag required.
- Cryptographic proof (provenance attestation) that the publish came from this specific repo + workflow.
- Aligns with npm's stated direction (classic Automation tokens are being phased out).

## Follow-up (after merge + first successful OIDC publish)

- Delete the \`NPM_TOKEN\` secret from the repo at https://github.com/salishforge/memforge/settings/secrets/actions.

## Test plan

- [ ] CI passes on this PR (no auth change — the publish step only runs on tag push, not PR)
- [ ] Trusted publisher configured on npm.com BEFORE the next release tag
- [ ] On next tag push, publish step runs without \`NODE_AUTH_TOKEN\` and succeeds