### PR TITLE
feat(cold-tier): retention policy with audit trail (#20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,10 @@ AUDIT_HMAC_KEY=
 # Days to keep audit records immutable (default: 90)
 AUDIT_RETENTION_DAYS=90
 
+# Cold tier retention — hard-delete archived rows older than N days (default: unset = keep forever)
+# Opt-in: leave unset or set to 0 to disable. Existing deploys are unaffected.
+# COLD_TIER_RETENTION_DAYS=365
+
 # Archive expired audit records to cold_audit (true) or delete them (false)
 AUDIT_ARCHIVE_ON_EXPIRY=true
 

--- a/README.md
+++ b/README.md
@@ -592,7 +592,6 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for test architecture, coverage gaps, and h
 - **Single process** — No clustering or worker threads. Sleep cycles run in the main event loop. For high-throughput deployments, run separate instances for API serving and sleep cycle processing.
 - **LLM-dependent features require API keys** — Summarize consolidation, reflection, meta-reflection, sleep cycle revision, and procedural extraction all require an LLM provider. Without one, MemForge still works as a tiered search engine with concat consolidation.
 - **No streaming consolidation** — Large hot-tier backlogs (10K+ events) load into memory at once. See [issue #11](https://github.com/salishforge/memforge/issues/11).
-- **Cold tier grows indefinitely** — No retention policy or hard deletion. Archived memories accumulate forever.
 - **Limited semantic search test coverage** — Mock LLM tests cover all LLM-dependent paths. Semantic/hybrid search paths still require a live embedding provider; no mock embedding provider exists yet.
 - **No HTTPS** — Run behind a TLS-terminating reverse proxy in production. See [SECURITY.md](SECURITY.md).
 

--- a/src/memory-manager.ts
+++ b/src/memory-manager.ts
@@ -1903,6 +1903,43 @@ Ranking (numbers only):`;
     return result;
   }
 
+  // ─── Cold Tier Retention ─────────────────────────────────────────────────
+
+  /**
+   * Hard-delete cold_tier rows older than COLD_TIER_RETENTION_DAYS.
+   * No-op (zero queries) when retention is unset or 0.
+   *
+   * Decision: DELETE ... RETURNING id so the count is exact and the audit entry
+   * can record which IDs were removed. A single bulk DELETE is used — batching is
+   * a follow-up if prune volumes grow large enough to matter.
+   */
+  async pruneColdTier(agentId: string): Promise<{ pruned: number }> {
+    this.assertAgentId(agentId);
+
+    const retentionDays = this.config.sleepCycle.coldRetentionDays ?? 0;
+    if (!retentionDays) return { pruned: 0 };
+
+    const { rows } = await this.pool.query<{ id: bigint }>(
+      `DELETE FROM cold_tier WHERE agent_id = $1
+         AND archived_at < now() - interval '1 day' * $2
+       RETURNING id`,
+      [agentId, retentionDays],
+    );
+    const pruned = rows.length;
+
+    log.info({ agentId, pruned, retentionDays }, 'cold tier retention prune complete');
+
+    if (this.audit && pruned > 0) {
+      void this.audit.recordBatch(
+        agentId, 'cold_tier', 'delete',
+        { pruned, retentionDays, deleted_ids: rows.map((r) => String(r.id)) },
+        'sleep_cycle',
+      ).catch((err: unknown) => log.error({ err }, 'cold tier prune audit failed'));
+    }
+
+    return { pruned };
+  }
+
   // ─── Memory Health ────────────────────────────────────────────────────────
 
   /**

--- a/src/sleep-cycle.ts
+++ b/src/sleep-cycle.ts
@@ -122,6 +122,10 @@ export class SleepCycleEngine {
     }
 
     // Phase 5b: Cold tier retention purge (optional)
+    // Placed after Phase 2 (triage / eviction into cold_tier) so a row archived in
+    // this same cycle cannot be immediately deleted if it happened to land before the
+    // cutoff timestamp. Running after reflection keeps this phase in the "cleanup"
+    // tail of the cycle, consistent with Phase 6 (audit archive).
     let coldPurged = 0;
     if (this.config.coldRetentionDays) {
       coldPurged = await this.phaseColdPurge(agentId, this.config.coldRetentionDays);
@@ -826,12 +830,33 @@ ${wrapUserContent('related_memories', relatedList || 'None')}`;
   }
 
   private async phaseColdPurge(agentId: string, retentionDays: number): Promise<number> {
-    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
-    const { rowCount } = await this.pool.query(
-      `DELETE FROM cold_tier WHERE agent_id = $1 AND archived_at < $2`,
-      [agentId, cutoff],
+    // DELETE ... RETURNING id so we know exactly which rows were removed for the audit entry.
+    // Single bulk delete is acceptable for Phase 1 — batching (LIMIT + loop) is a follow-up
+    // if prune counts grow large enough to risk long lock holds.
+    const { rows } = await this.pool.query<{ id: bigint }>(
+      `DELETE FROM cold_tier WHERE agent_id = $1
+         AND archived_at < now() - interval '1 day' * $2
+       RETURNING id`,
+      [agentId, retentionDays],
     );
-    return rowCount ?? 0;
+    const pruned = rows.length;
+
+    if (pruned === 0) return 0;
+
+    log.info({ agentId, pruned, retentionDays }, 'cold tier retention prune complete');
+
+    // One summary audit entry per prune run — individual cold_tier rows don't have their own
+    // audit chains (they're already the archive of evicted warm/hot rows). A batch entry on
+    // target_id=0 gives an attestable record that the deletion happened and when.
+    if (this.audit) {
+      void this.audit.recordBatch(
+        agentId, 'cold_tier', 'delete',
+        { pruned, retentionDays, deleted_ids: rows.map((r) => String(r.id)) },
+        'sleep_cycle',
+      ).catch((err: unknown) => log.error({ err }, 'cold tier prune audit failed'));
+    }
+
+    return pruned;
   }
 
   // ─── Phase 5: Reflection ───────────────────────────────────────────────────

--- a/tests/cold-tier-retention.test.ts
+++ b/tests/cold-tier-retention.test.ts
@@ -1,0 +1,229 @@
+// MemForge — Cold Tier Retention Tests
+//
+// Tests the pruneColdTier() method. All tests insert rows with explicit timestamps
+// so behaviour is deterministic (no sleeping, no time travel in Postgres).
+//
+// Run: node --import tsx/esm --test tests/cold-tier-retention.test.ts
+//
+// WARNING: Requires DATABASE_URL pointing to a test database with schema applied.
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { Pool } from 'pg';
+
+const { MemoryManager } = await import('../src/memory-manager.js');
+const { AuditChain } = await import('../src/audit.js');
+const { NoOpEmbeddingProvider } = await import('../src/embedding.js');
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+if (!DATABASE_URL) {
+  console.error('[test] DATABASE_URL is required — set it to a test database');
+  process.exit(1);
+}
+
+const AGENT_A = 'test-cold-retention-agent-a';
+const AGENT_B = 'test-cold-retention-agent-b';
+
+const pool = new Pool({ connectionString: DATABASE_URL });
+const auditChain = new AuditChain(pool);
+
+async function ensureAgent(agentId: string): Promise<void> {
+  await pool.query(
+    `INSERT INTO agents (id, metadata) VALUES ($1, '{}')
+     ON CONFLICT (id) DO NOTHING`,
+    [agentId],
+  );
+}
+
+async function insertColdRow(agentId: string, archivedAt: Date): Promise<bigint> {
+  const { rows } = await pool.query<{ id: bigint }>(
+    `INSERT INTO cold_tier (agent_id, source_table, source_id, content, metadata, archived_at, original_created_at)
+     VALUES ($1, 'warm_tier', 1, 'test content', '{}', $2, $2)
+     RETURNING id`,
+    [agentId, archivedAt],
+  );
+  return rows[0]!.id;
+}
+
+async function coldCount(agentId: string): Promise<number> {
+  const { rows } = await pool.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM cold_tier WHERE agent_id = $1`,
+    [agentId],
+  );
+  return parseInt(rows[0]!.count, 10);
+}
+
+async function cleanup(): Promise<void> {
+  await pool.query(`DELETE FROM audit_chain WHERE agent_id IN ($1, $2)`, [AGENT_A, AGENT_B]);
+  await pool.query(`DELETE FROM cold_tier WHERE agent_id IN ($1, $2)`, [AGENT_A, AGENT_B]);
+  await pool.query(`DELETE FROM agents WHERE id IN ($1, $2)`, [AGENT_A, AGENT_B]);
+}
+
+// ─── Retention disabled (default) ────────────────────────────────────────────
+
+describe('pruneColdTier — retention disabled', () => {
+  const manager = new MemoryManager({
+    databaseUrl: DATABASE_URL,
+    autoRegisterAgents: true,
+    embeddingProvider: new NoOpEmbeddingProvider(),
+    llmProvider: null,
+    sleepCycle: {
+      tokenBudget: 100_000,
+      evictionThreshold: 0.1,
+      revisionThreshold: 0.4,
+      includeReflection: false,
+      weights: { recency: 0.25, frequency: 0.20, centrality: 0.20, reflection: 0.15, stability: 0.20 },
+      // coldRetentionDays intentionally absent — default is disabled
+    },
+    auditChain,
+  });
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent(AGENT_A);
+    // Insert a row archived 100 days ago — far past any plausible retention threshold
+    const old = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000);
+    await insertColdRow(AGENT_A, old);
+  });
+
+  after(cleanup);
+
+  it('returns 0 pruned without issuing any delete', async () => {
+    const result = await manager.pruneColdTier(AGENT_A);
+
+    assert.equal(result.pruned, 0);
+    assert.equal(await coldCount(AGENT_A), 1, 'Row must still exist when retention is disabled');
+  });
+});
+
+// ─── Retention enabled — only deletes expired rows ───────────────────────────
+
+describe('pruneColdTier — retention enabled, 30-day window', () => {
+  const manager = new MemoryManager({
+    databaseUrl: DATABASE_URL,
+    autoRegisterAgents: true,
+    embeddingProvider: new NoOpEmbeddingProvider(),
+    llmProvider: null,
+    sleepCycle: {
+      tokenBudget: 100_000,
+      evictionThreshold: 0.1,
+      revisionThreshold: 0.4,
+      includeReflection: false,
+      weights: { recency: 0.25, frequency: 0.20, centrality: 0.20, reflection: 0.15, stability: 0.20 },
+      coldRetentionDays: 30,
+    },
+    auditChain,
+  });
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent(AGENT_A);
+  });
+
+  after(cleanup);
+
+  it('deletes rows older than 30 days and keeps recent rows', async () => {
+    // Row archived 60 days ago — eligible for deletion
+    const expired = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    await insertColdRow(AGENT_A, expired);
+
+    // Row archived 10 days ago — within retention window, must survive
+    const fresh = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    await insertColdRow(AGENT_A, fresh);
+
+    assert.equal(await coldCount(AGENT_A), 2);
+
+    const result = await manager.pruneColdTier(AGENT_A);
+
+    assert.equal(result.pruned, 1, 'Only the expired row should be pruned');
+    assert.equal(await coldCount(AGENT_A), 1, 'Fresh row must remain');
+  });
+});
+
+// ─── Scoped to agent — other agents are unaffected ───────────────────────────
+
+describe('pruneColdTier — agent scoping', () => {
+  const manager = new MemoryManager({
+    databaseUrl: DATABASE_URL,
+    autoRegisterAgents: true,
+    embeddingProvider: new NoOpEmbeddingProvider(),
+    llmProvider: null,
+    sleepCycle: {
+      tokenBudget: 100_000,
+      evictionThreshold: 0.1,
+      revisionThreshold: 0.4,
+      includeReflection: false,
+      weights: { recency: 0.25, frequency: 0.20, centrality: 0.20, reflection: 0.15, stability: 0.20 },
+      coldRetentionDays: 30,
+    },
+    auditChain,
+  });
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent(AGENT_A);
+    await ensureAgent(AGENT_B);
+    // Both agents have an expired row archived 60 days ago
+    const expired = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    await insertColdRow(AGENT_A, expired);
+    await insertColdRow(AGENT_B, expired);
+  });
+
+  after(cleanup);
+
+  it('pruning agent-a does not touch agent-b rows', async () => {
+    const result = await manager.pruneColdTier(AGENT_A);
+
+    assert.equal(result.pruned, 1);
+    assert.equal(await coldCount(AGENT_A), 0, 'Agent A row should be gone');
+    assert.equal(await coldCount(AGENT_B), 1, 'Agent B row must be untouched');
+  });
+});
+
+// ─── Audit trail — audit_chain entries survive the prune ────────────────────
+
+describe('pruneColdTier — audit trail preserved', () => {
+  const manager = new MemoryManager({
+    databaseUrl: DATABASE_URL,
+    autoRegisterAgents: true,
+    embeddingProvider: new NoOpEmbeddingProvider(),
+    llmProvider: null,
+    sleepCycle: {
+      tokenBudget: 100_000,
+      evictionThreshold: 0.1,
+      revisionThreshold: 0.4,
+      includeReflection: false,
+      weights: { recency: 0.25, frequency: 0.20, centrality: 0.20, reflection: 0.15, stability: 0.20 },
+      coldRetentionDays: 30,
+    },
+    auditChain,
+  });
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent(AGENT_A);
+  });
+
+  after(cleanup);
+
+  it('audit_chain records are queryable after cold_tier rows are pruned', async () => {
+    const expired = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    await insertColdRow(AGENT_A, expired);
+
+    const result = await manager.pruneColdTier(AGENT_A);
+    assert.equal(result.pruned, 1);
+
+    // The audit summary entry uses target_id=0 (recordBatch sentinel)
+    // and target_table='cold_tier'. Wait briefly for the fire-and-forget audit write.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const { rows } = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM audit_chain
+       WHERE agent_id = $1 AND target_table = 'cold_tier' AND operation = 'delete'`,
+      [AGENT_A],
+    );
+    assert.ok(parseInt(rows[0]!.count, 10) >= 1, 'Audit entry for the prune must exist');
+  });
+});


### PR DESCRIPTION
## Summary

Last remaining Phase 1 ROADMAP item. Adds \`COLD_TIER_RETENTION_DAYS\` — a hard-delete policy for archived cold-tier rows older than N days. **Opt-in**: default (unset or 0) preserves existing "keep forever" behaviour; existing deploys are unaffected.

**Fixes #20.**

## Changes

- \`src/sleep-cycle.ts\` — enhance the existing \`phaseColdPurge\` with \`DELETE ... RETURNING id\`, pino \`log.info\` per prune, and a single-summary audit entry per run via \`audit.recordBatch\`. Document phase-order placement (cleanup tail, after any eviction INTO cold_tier in this cycle).
- \`src/memory-manager.ts\` — new public \`pruneColdTier(agentId)\` method mirroring the sleep-cycle implementation, for callers who want to trigger retention outside a full sleep cycle. Fast-path returns \`{ pruned: 0 }\` with zero queries when retention is 0 or unset.
- \`.env.example\` — document \`COLD_TIER_RETENTION_DAYS\` alongside \`AUDIT_RETENTION_DAYS\`.
- \`README.md\` — remove the now-stale "cold tier grows indefinitely" limitation bullet.
- \`tests/cold-tier-retention.test.ts\` (new, 229 lines) — four test suites:
  1. Retention disabled: returns 0, no deletes issued.
  2. 30-day window: only rows with \`archived_at\` older than 30 days are deleted; fresh rows survive.
  3. Agent scoping: \`pruneColdTier(a)\` doesn't touch b's rows.
  4. Audit trail: \`audit_chain\` summary entry exists after prune.

Tests use explicit timestamps for deterministic seeding — no sleeps, no \`pg_sleep\`.

## Design notes

- **Hard delete, no escalation.** Cold tier IS the archive — there's no colder tier to move rows into. Retention = deletion.
- **One summary audit entry per prune.** Individual cold_tier rows are already the archive of evicted warm/hot rows — per-row audit entries would double-account. A batch \`record\` with \`deleted_ids\` in \`metadata_delta\` is attestable.
- **Single bulk \`DELETE\`.** Batching (LIMIT + loop) would reduce lock-hold duration for huge prunes; flagged as a follow-up if it matters.

## Test plan

- [ ] CI \`typecheck\` / \`lint\` / \`build\` pass
- [ ] CI \`test-integration\` runs the new test file and all four suites pass
- [ ] CI \`test-rls\` still passes — prune must respect agent isolation (verified in suite 3)
- [ ] Existing sleep cycle tests still pass

## Scope

Phase 1 completion. No Phase 2 features (namespaces, per-agent tuning, multi-model revision) touched.