### PR TITLE
feat(namespaces): memory namespaces backend — schema + MemoryManager + tests (Sprint C.1, #16)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,8 +56,8 @@ All Phase 1 items are implemented:
 
 ### Memory Lifecycle Management
 
-- **Memory namespaces** — Partition memories by domain, project, or context so agents with broad responsibilities maintain focused retrieval ([#16](https://github.com/salishforge/memforge/issues/16))
-- **Per-agent importance tuning** — Different agents need different memory profiles. A support agent should weight recency; a research agent should weight graph centrality ([#17](https://github.com/salishforge/memforge/issues/17))
+- **Memory namespaces** — Partition memories by domain, project, or context so agents with broad responsibilities maintain focused retrieval ([#16](https://github.com/salishforge/memforge/issues/16)) — *in progress: backend (schema + MemoryManager + tests) in PR #TBD; HTTP/MCP/SDK/OpenAPI surface in follow-up (C.2)*
+- **Per-agent importance tuning** — Different agents need different memory profiles. A support agent should weight recency; a research agent should weight graph centrality ([#17](https://github.com/salishforge/memforge/issues/17)) — ✅ DONE: shipped in v2.4 migration (#57) — `agents.scoring_weights` JSONB column wired into sleep cycle phase 1
 - **Cold tier search and restoration** — Query archived memories and selectively restore them when context shifts back to old topics ([#14](https://github.com/salishforge/memforge/issues/14))
 
 ### Intelligent Resource Management

--- a/schema/migration-v3.1.sql
+++ b/schema/migration-v3.1.sql
@@ -1,0 +1,87 @@
+-- MemForge — Migration v3.1: Memory Namespaces
+-- Adds `namespace` to the 8 memory tables (hot, warm, cold, reflections,
+-- procedures, consolidation_log, retrieval_log, memory_revisions).
+--
+-- Entities and relationships are intentionally NOT namespaced — they are
+-- agent-scoped. A single entity (e.g. "User Sarah") can appear across many
+-- namespace contexts for the same agent; duplicating it per namespace would
+-- fragment the knowledge graph and break cross-namespace entity reuse.
+-- The warm_tier_entities junction stays unchanged: a warm row (which IS
+-- namespaced) already carries the namespace; the linked entities do not need it.
+--
+-- Safe to re-run: ADD COLUMN IF NOT EXISTS (PG 17+) inside DO blocks for
+-- older Postgres, CREATE INDEX IF NOT EXISTS for indexes.
+--
+-- Apply: psql "$DATABASE_URL" -f schema/migration-v3.1.sql
+
+-- ─── hot_tier ────────────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+  ALTER TABLE hot_tier ADD COLUMN namespace TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS hot_tier_namespace_idx ON hot_tier (agent_id, namespace);
+
+-- ─── warm_tier ───────────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+  ALTER TABLE warm_tier ADD COLUMN namespace TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS warm_tier_namespace_idx ON warm_tier (agent_id, namespace);
+
+-- ─── cold_tier ───────────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+  ALTER TABLE cold_tier ADD COLUMN namespace TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS cold_tier_namespace_idx ON cold_tier (agent_id, namespace);
+
+-- ─── reflections ─────────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+  ALTER TABLE reflections ADD COLUMN namespace TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS reflections_namespace_idx ON reflections (agent_id, namespace);
+
+-- ─── procedures ──────────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+  ALTER TABLE procedures ADD COLUMN namespace TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS procedures_namespace_idx ON procedures (agent_id, namespace);
+
+-- ─── consolidation_log ───────────────────────────────────────────────────────
+
+DO $$ BEGIN
+  ALTER TABLE consolidation_log ADD COLUMN namespace TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS consolidation_log_namespace_idx ON consolidation_log (agent_id, namespace);
+
+-- ─── retrieval_log ───────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+  ALTER TABLE retrieval_log ADD COLUMN namespace TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS retrieval_log_namespace_idx ON retrieval_log (agent_id, namespace);
+
+-- ─── memory_revisions ────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+  ALTER TABLE memory_revisions ADD COLUMN namespace TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS memory_revisions_namespace_idx ON memory_revisions (agent_id, namespace);

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1,6 +1,9 @@
 -- MemForge — PostgreSQL Canonical Schema
--- Single-file fresh-install schema incorporating all migrations through v3.0.
+-- Single-file fresh-install schema incorporating all migrations through v3.1.
 -- To install: psql "$DATABASE_URL" -f schema/schema.sql
+-- As of v3.1.0, namespace column added to memory tables (hot/warm/cold/reflections/
+-- procedures/consolidation_log/retrieval_log/memory_revisions). Entities and
+-- relationships remain agent-scoped only — see migration-v3.1.sql for rationale.
 -- As of v3.0.0-beta.3, RLS policies and the audit delete trigger are included
 -- here by default. Fresh installs are secure-by-default. Existing v2.2 deploys
 -- must still run migration-v2.3.sql (which remains functional for that purpose).
@@ -28,6 +31,7 @@ CREATE TABLE IF NOT EXISTS agents (
 -- ─────────────────────────────────────────────────────────────────────────────
 -- hot_tier — recent raw events (write-heavy, fast ingestion)
 -- Added in v2.4: content_hash
+-- Added in v3.1: namespace
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS hot_tier (
   id           BIGSERIAL   PRIMARY KEY,
@@ -35,12 +39,14 @@ CREATE TABLE IF NOT EXISTS hot_tier (
   content      TEXT        NOT NULL,
   metadata     JSONB       NOT NULL DEFAULT '{}',
   created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
-  content_hash TEXT
+  content_hash TEXT,
+  namespace    TEXT        NOT NULL DEFAULT 'default'
 );
 
 CREATE INDEX IF NOT EXISTS hot_tier_agent_id_idx     ON hot_tier (agent_id);
 CREATE INDEX IF NOT EXISTS hot_tier_created_at_idx   ON hot_tier (created_at DESC);
 CREATE INDEX IF NOT EXISTS hot_tier_content_hash_idx ON hot_tier (agent_id, content_hash);
+CREATE INDEX IF NOT EXISTS hot_tier_namespace_idx    ON hot_tier (agent_id, namespace);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- warm_tier — consolidated, full-text-searchable memory with embeddings
@@ -50,6 +56,7 @@ CREATE INDEX IF NOT EXISTS hot_tier_content_hash_idx ON hot_tier (agent_id, cont
 -- v2.4: outcome_type, graduated, retrieval_success_count, first_successful_retrieval,
 --        content_code_tsv, summary (v2.5)
 -- v2.6: surprise_score, staleness_score, last_corroborated
+-- v3.1: namespace
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS warm_tier (
   id                          BIGSERIAL   PRIMARY KEY,
@@ -86,7 +93,9 @@ CREATE TABLE IF NOT EXISTS warm_tier (
   -- Active knowledge management (#79, #78)
   surprise_score              REAL        NOT NULL DEFAULT 0,
   staleness_score             REAL        NOT NULL DEFAULT 0,
-  last_corroborated           TIMESTAMPTZ
+  last_corroborated           TIMESTAMPTZ,
+  -- Namespace partitioning (#16) — defaults to 'default' so existing callers are unaffected
+  namespace                   TEXT        NOT NULL DEFAULT 'default'
 );
 
 CREATE INDEX IF NOT EXISTS warm_tier_agent_id_idx   ON warm_tier (agent_id);
@@ -96,9 +105,11 @@ CREATE INDEX IF NOT EXISTS warm_tier_hot_ids_idx    ON warm_tier USING GIN (sour
 CREATE INDEX IF NOT EXISTS warm_tier_embedding_idx  ON warm_tier USING hnsw (embedding halfvec_cosine_ops);
 CREATE INDEX IF NOT EXISTS warm_tier_time_idx       ON warm_tier (agent_id, time_start, time_end);
 CREATE INDEX IF NOT EXISTS warm_tier_importance_idx ON warm_tier (agent_id, importance DESC);
+CREATE INDEX IF NOT EXISTS warm_tier_namespace_idx  ON warm_tier (agent_id, namespace);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- cold_tier — archived / cleared memory (audit trail, never hard-deleted)
+-- Added in v3.1: namespace
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS cold_tier (
   id                  BIGSERIAL   PRIMARY KEY,
@@ -108,15 +119,18 @@ CREATE TABLE IF NOT EXISTS cold_tier (
   content             TEXT        NOT NULL,
   metadata            JSONB       NOT NULL DEFAULT '{}',
   archived_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
-  original_created_at TIMESTAMPTZ NOT NULL
+  original_created_at TIMESTAMPTZ NOT NULL,
+  namespace           TEXT        NOT NULL DEFAULT 'default'
 );
 
 CREATE INDEX IF NOT EXISTS cold_tier_agent_id_idx    ON cold_tier (agent_id);
 CREATE INDEX IF NOT EXISTS cold_tier_source_idx      ON cold_tier (source_table, source_id);
 CREATE INDEX IF NOT EXISTS cold_tier_archived_at_idx ON cold_tier (archived_at DESC);
+CREATE INDEX IF NOT EXISTS cold_tier_namespace_idx   ON cold_tier (agent_id, namespace);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- consolidation_log — audit trail for consolidation runs
+-- Added in v3.1: namespace
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS consolidation_log (
   id                  BIGSERIAL   PRIMARY KEY,
@@ -128,11 +142,13 @@ CREATE TABLE IF NOT EXISTS consolidation_log (
   status              TEXT        NOT NULL DEFAULT 'running'
                                     CHECK (status IN ('running', 'complete', 'failed')),
   error               TEXT,
-  metadata            JSONB       NOT NULL DEFAULT '{}'
+  metadata            JSONB       NOT NULL DEFAULT '{}',
+  namespace           TEXT        NOT NULL DEFAULT 'default'
 );
 
-CREATE INDEX IF NOT EXISTS consolidation_log_agent_id_idx ON consolidation_log (agent_id);
-CREATE INDEX IF NOT EXISTS consolidation_log_started_idx  ON consolidation_log (started_at DESC);
+CREATE INDEX IF NOT EXISTS consolidation_log_agent_id_idx  ON consolidation_log (agent_id);
+CREATE INDEX IF NOT EXISTS consolidation_log_started_idx   ON consolidation_log (started_at DESC);
+CREATE INDEX IF NOT EXISTS consolidation_log_namespace_idx ON consolidation_log (agent_id, namespace);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- entities — knowledge graph nodes extracted during consolidation
@@ -190,6 +206,7 @@ CREATE INDEX IF NOT EXISTS warm_tier_entities_entity_idx ON warm_tier_entities (
 -- ─────────────────────────────────────────────────────────────────────────────
 -- reflections — synthesized insights from periodic LLM review
 -- Added in v2.1: reflection_level, source_reflection_ids (meta-reflection)
+-- Added in v3.1: namespace
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS reflections (
   id                    BIGSERIAL   PRIMARY KEY,
@@ -204,16 +221,20 @@ CREATE TABLE IF NOT EXISTS reflections (
   created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
   -- Meta-reflection hierarchy (#v2.1)
   reflection_level      INT         NOT NULL DEFAULT 1,
-  source_reflection_ids BIGINT[]    NOT NULL DEFAULT '{}'
+  source_reflection_ids BIGINT[]    NOT NULL DEFAULT '{}',
+  -- Namespace partitioning (#16)
+  namespace             TEXT        NOT NULL DEFAULT 'default'
 );
 
-CREATE INDEX IF NOT EXISTS reflections_agent_id_idx ON reflections (agent_id);
-CREATE INDEX IF NOT EXISTS reflections_created_idx  ON reflections (created_at DESC);
-CREATE INDEX IF NOT EXISTS reflections_level_idx    ON reflections (agent_id, reflection_level);
+CREATE INDEX IF NOT EXISTS reflections_agent_id_idx  ON reflections (agent_id);
+CREATE INDEX IF NOT EXISTS reflections_created_idx   ON reflections (created_at DESC);
+CREATE INDEX IF NOT EXISTS reflections_level_idx     ON reflections (agent_id, reflection_level);
+CREATE INDEX IF NOT EXISTS reflections_namespace_idx ON reflections (agent_id, namespace);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- retrieval_log — records every query hit for reinforcement analysis
 -- Added in v2.1: outcome, feedback_at, feedback_metadata
+-- Added in v3.1: namespace
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS retrieval_log (
   id                BIGSERIAL   PRIMARY KEY,
@@ -227,16 +248,20 @@ CREATE TABLE IF NOT EXISTS retrieval_log (
   -- Downstream outcome feedback (#v2.1)
   outcome           TEXT        CHECK (outcome IN ('positive', 'negative', 'neutral')),
   feedback_at       TIMESTAMPTZ,
-  feedback_metadata JSONB       NOT NULL DEFAULT '{}'
+  feedback_metadata JSONB       NOT NULL DEFAULT '{}',
+  -- Namespace partitioning (#16)
+  namespace         TEXT        NOT NULL DEFAULT 'default'
 );
 
-CREATE INDEX IF NOT EXISTS retrieval_log_agent_idx   ON retrieval_log (agent_id);
-CREATE INDEX IF NOT EXISTS retrieval_log_warm_idx    ON retrieval_log (warm_tier_id);
-CREATE INDEX IF NOT EXISTS retrieval_log_created_idx ON retrieval_log (created_at DESC);
-CREATE INDEX IF NOT EXISTS retrieval_log_outcome_idx ON retrieval_log (agent_id, outcome) WHERE outcome IS NOT NULL;
+CREATE INDEX IF NOT EXISTS retrieval_log_agent_idx     ON retrieval_log (agent_id);
+CREATE INDEX IF NOT EXISTS retrieval_log_warm_idx      ON retrieval_log (warm_tier_id);
+CREATE INDEX IF NOT EXISTS retrieval_log_created_idx   ON retrieval_log (created_at DESC);
+CREATE INDEX IF NOT EXISTS retrieval_log_outcome_idx   ON retrieval_log (agent_id, outcome) WHERE outcome IS NOT NULL;
+CREATE INDEX IF NOT EXISTS retrieval_log_namespace_idx ON retrieval_log (agent_id, namespace);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- memory_revisions — tracks every rewrite of a warm-tier memory
+-- Added in v3.1: namespace
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS memory_revisions (
   id               BIGSERIAL   PRIMARY KEY,
@@ -250,14 +275,18 @@ CREATE TABLE IF NOT EXISTS memory_revisions (
   delta_summary    TEXT        NOT NULL DEFAULT '',
   confidence       REAL        NOT NULL DEFAULT 0.5,
   model_used       TEXT        NOT NULL DEFAULT '',
-  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Namespace partitioning (#16)
+  namespace        TEXT        NOT NULL DEFAULT 'default'
 );
 
-CREATE INDEX IF NOT EXISTS memory_revisions_agent_idx ON memory_revisions (agent_id);
-CREATE INDEX IF NOT EXISTS memory_revisions_warm_idx  ON memory_revisions (warm_tier_id);
+CREATE INDEX IF NOT EXISTS memory_revisions_agent_idx     ON memory_revisions (agent_id);
+CREATE INDEX IF NOT EXISTS memory_revisions_warm_idx      ON memory_revisions (warm_tier_id);
+CREATE INDEX IF NOT EXISTS memory_revisions_namespace_idx ON memory_revisions (agent_id, namespace);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- procedures — learned condition→action rules (procedural memory)
+-- Added in v3.1: namespace
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS procedures (
   id                   BIGSERIAL   PRIMARY KEY,
@@ -270,11 +299,14 @@ CREATE TABLE IF NOT EXISTS procedures (
   last_accessed        TIMESTAMPTZ,
   active               BOOLEAN     NOT NULL DEFAULT true,
   metadata             JSONB       NOT NULL DEFAULT '{}',
-  created_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Namespace partitioning (#16)
+  namespace            TEXT        NOT NULL DEFAULT 'default'
 );
 
-CREATE INDEX IF NOT EXISTS procedures_agent_idx  ON procedures (agent_id);
-CREATE INDEX IF NOT EXISTS procedures_active_idx ON procedures (agent_id, active) WHERE active = true;
+CREATE INDEX IF NOT EXISTS procedures_agent_idx      ON procedures (agent_id);
+CREATE INDEX IF NOT EXISTS procedures_active_idx     ON procedures (agent_id, active) WHERE active = true;
+CREATE INDEX IF NOT EXISTS procedures_namespace_idx  ON procedures (agent_id, namespace);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- audit_chain — immutable hash-chained audit log of all warm-tier mutations

--- a/src/memory-manager.ts
+++ b/src/memory-manager.ts
@@ -12,7 +12,7 @@ import { NoOpEmbeddingProvider } from './embedding.js';
 import type { EmbeddingProvider } from './embedding.js';
 import { REFLECTION_SYSTEM_PROMPT, PROCEDURE_EXTRACTION_PROMPT, wrapUserContent } from './llm.js';
 import type { LLMProvider, ConsolidationSummary } from './llm.js';
-import { safeParseLLMResponse, ReflectionResponseSchema, ProcedureExtractionSchema } from './schemas.js';
+import { safeParseLLMResponse, ReflectionResponseSchema, ProcedureExtractionSchema, NamespaceSchema } from './schemas.js';
 import { SleepCycleEngine } from './sleep-cycle.js';
 import type { AuditChain } from './audit.js';
 import { getLogger } from './logger.js';
@@ -26,6 +26,7 @@ import type {
   QueryOptions,
   QueryMode,
   ConsolidateResult,
+  ConsolidateOptions,
   ClearResult,
   AgentStats,
   TimelineEntry,
@@ -49,6 +50,17 @@ import type {
   MemoryHints,
   SqlParam,
 } from './types.js';
+const DEFAULT_NAMESPACE = 'default';
+
+/** Resolve and validate a caller-supplied namespace, defaulting to 'default'. */
+function resolveNamespace(ns: string | undefined): string {
+  if (!ns) return DEFAULT_NAMESPACE;
+  const result = NamespaceSchema.safeParse(ns);
+  if (!result.success) {
+    throw new TypeError(`Invalid namespace '${ns}': ${result.error.issues[0]?.message ?? 'validation failed'}`);
+  }
+  return result.data;
+}
 
 const DEFAULTS: MemForgeConfig = {
   databaseUrl: process.env['DATABASE_URL'] ?? '',
@@ -190,23 +202,27 @@ export class MemoryManager {
     metadata: Record<string, unknown> = {},
     outcomeType: OutcomeType = 'neutral',
     hints?: MemoryHints,
+    namespace?: string,
   ): Promise<AddResult> {
     this.assertAgentId(agentId);
     if (!content || typeof content !== 'string') {
       throw new TypeError('content must be a non-empty string');
     }
 
+    const ns = resolveNamespace(namespace);
+
     if (this.config.autoRegisterAgents) {
       await this.registerAgent(agentId);
     }
 
-    // Deduplicate by content hash — skip storing if identical content was added recently
+    // Deduplicate by content hash — skip storing if identical content was added recently.
+    // Dedup is namespace-scoped: the same content in different namespaces is stored independently.
     const contentHash = createHash('sha256').update(content).digest('hex');
     const dup = await this.pool.query<{ id: bigint; created_at: Date }>(
       `SELECT id, created_at FROM hot_tier
-       WHERE agent_id = $1 AND content_hash = $2 AND created_at > now() - interval '1 hour'
+       WHERE agent_id = $1 AND content_hash = $2 AND namespace = $3 AND created_at > now() - interval '1 hour'
        LIMIT 1`,
-      [agentId, contentHash],
+      [agentId, contentHash, ns],
     );
     if (dup.rows[0]) {
       await this.pool.query(`UPDATE hot_tier SET created_at = now() WHERE id = $1`, [dup.rows[0].id]);
@@ -233,10 +249,10 @@ export class MemoryManager {
     }
 
     const { rows } = await this.pool.query<AddResult>(
-      `INSERT INTO hot_tier (agent_id, content, metadata, content_hash)
-       VALUES ($1, $2, $3, $4)
+      `INSERT INTO hot_tier (agent_id, content, metadata, content_hash, namespace)
+       VALUES ($1, $2, $3, $4, $5)
        RETURNING id, agent_id, created_at`,
-      [agentId, content, JSON.stringify(enrichedMetadata), contentHash],
+      [agentId, content, JSON.stringify(enrichedMetadata), contentHash, ns],
     );
 
     const result = rows[0]!;
@@ -329,6 +345,8 @@ Ranking (numbers only):`;
       throw new TypeError('search query must be a non-empty string');
     }
 
+    const ns = resolveNamespace(opts.namespace);
+
     // Query understanding: clean scaffolding, extract time hints, split compounds
     const parsed = parseQuery(opts.q);
     const searchText = parsed.cleanedText;
@@ -351,10 +369,10 @@ Ranking (numbers only):`;
       for (const subQ of parsed.subQueries.slice(0, 3)) { // cap at 3 sub-queries
         let subResults: QueryResult[];
         switch (mode) {
-          case 'keyword': subResults = await this.queryKeyword(agentId, subQ, subLimit, after, before); break;
-          case 'semantic': subResults = await this.querySemantic(agentId, subQ, subLimit, after, before); break;
-          case 'hybrid': subResults = await this.queryHybrid(agentId, subQ, subLimit, after, before); break;
-          default: subResults = await this.queryKeyword(agentId, subQ, subLimit, after, before);
+          case 'keyword': subResults = await this.queryKeyword(agentId, subQ, subLimit, after, before, ns); break;
+          case 'semantic': subResults = await this.querySemantic(agentId, subQ, subLimit, after, before, ns); break;
+          case 'hybrid': subResults = await this.queryHybrid(agentId, subQ, subLimit, after, before, ns); break;
+          default: subResults = await this.queryKeyword(agentId, subQ, subLimit, after, before, ns);
         }
         for (const r of subResults) {
           const key = String(r.id);
@@ -369,16 +387,16 @@ Ranking (numbers only):`;
       // Single query path (most common)
       switch (mode) {
         case 'keyword':
-          results = await this.queryKeyword(agentId, searchText, resolvedLimit, after, before);
+          results = await this.queryKeyword(agentId, searchText, resolvedLimit, after, before, ns);
           break;
         case 'code':
-          results = await this.queryCode(agentId, searchText, resolvedLimit, after, before);
+          results = await this.queryCode(agentId, searchText, resolvedLimit, after, before, ns);
           break;
         case 'semantic':
-          results = await this.querySemantic(agentId, searchText, resolvedLimit, after, before);
+          results = await this.querySemantic(agentId, searchText, resolvedLimit, after, before, ns);
           break;
         case 'hybrid':
-          results = await this.queryHybrid(agentId, searchText, resolvedLimit, after, before);
+          results = await this.queryHybrid(agentId, searchText, resolvedLimit, after, before, ns);
           break;
       }
     }
@@ -571,9 +589,9 @@ Ranking (numbers only):`;
       const warmIds = results.map((r) => r.id);
       const positions = results.map((_, idx) => idx + 1);
       void this.pool.query(
-        `INSERT INTO retrieval_log (agent_id, warm_tier_id, query_text, query_mode, rank_position)
-         SELECT $1, unnest($2::bigint[]), $3, $4, unnest($5::int[])`,
-        [agentId, warmIds, opts.q, mode, positions],
+        `INSERT INTO retrieval_log (agent_id, warm_tier_id, query_text, query_mode, rank_position, namespace)
+         SELECT $1, unnest($2::bigint[]), $3, $4, unnest($5::int[]), $6`,
+        [agentId, warmIds, opts.q, mode, positions, ns],
       ).catch((err) => log.error({ err }, 'retrieval log failed'));
     }
 
@@ -588,9 +606,10 @@ Ranking (numbers only):`;
     limit: number,
     after?: Date,
     before?: Date,
+    namespace: string = DEFAULT_NAMESPACE,
   ): Promise<QueryResult[]> {
-    const timeFilter = this.buildTimeFilter(after, before, 3);
-    const params: SqlParam[] =[agentId, searchText];
+    const timeFilter = this.buildTimeFilter(after, before, 4);
+    const params: SqlParam[] =[agentId, searchText, namespace];
     if (after) params.push(after);
     if (before) params.push(before);
     params.push(limit);
@@ -601,6 +620,7 @@ Ranking (numbers only):`;
               ts_rank_cd(content_tsv, plainto_tsquery('english', $2)) * (0.5 + 0.5 * importance) AS rank
        FROM warm_tier
        WHERE agent_id = $1
+         AND namespace = $3
          AND content_tsv @@ plainto_tsquery('english', $2)
          ${timeFilter}
        ORDER BY rank DESC
@@ -609,7 +629,7 @@ Ranking (numbers only):`;
     );
 
     if (rows.length === 0) {
-      return this.queryTrigram(agentId, searchText, limit, after, before);
+      return this.queryTrigram(agentId, searchText, limit, after, before, namespace);
     }
 
     return rows;
@@ -625,9 +645,10 @@ Ranking (numbers only):`;
     limit: number,
     after?: Date,
     before?: Date,
+    namespace: string = DEFAULT_NAMESPACE,
   ): Promise<QueryResult[]> {
-    const timeFilter = this.buildTimeFilter(after, before, 3);
-    const params: SqlParam[] =[agentId, searchText];
+    const timeFilter = this.buildTimeFilter(after, before, 4);
+    const params: SqlParam[] =[agentId, searchText, namespace];
     if (after) params.push(after);
     if (before) params.push(before);
     params.push(limit);
@@ -638,6 +659,7 @@ Ranking (numbers only):`;
               ts_rank_cd(content_code_tsv, plainto_tsquery('simple', $2)) * (0.5 + 0.5 * importance) AS rank
        FROM warm_tier
        WHERE agent_id = $1
+         AND namespace = $3
          AND content_code_tsv @@ plainto_tsquery('simple', $2)
          ${timeFilter}
        ORDER BY rank DESC
@@ -647,7 +669,7 @@ Ranking (numbers only):`;
 
     // Fall back to trigram if FTS returns nothing
     if (rows.length === 0) {
-      return this.queryTrigram(agentId, searchText, limit, after, before);
+      return this.queryTrigram(agentId, searchText, limit, after, before, namespace);
     }
 
     return rows;
@@ -659,9 +681,10 @@ Ranking (numbers only):`;
     limit: number,
     after?: Date,
     before?: Date,
+    namespace: string = DEFAULT_NAMESPACE,
   ): Promise<QueryResult[]> {
-    const params: SqlParam[] =[agentId, searchText, `%${escapeLike(searchText)}%`];
-    const timeFilter = this.buildTimeFilter(after, before, 4);
+    const params: SqlParam[] =[agentId, searchText, `%${escapeLike(searchText)}%`, namespace];
+    const timeFilter = this.buildTimeFilter(after, before, 5);
     if (after) params.push(after);
     if (before) params.push(before);
     params.push(limit);
@@ -672,6 +695,7 @@ Ranking (numbers only):`;
               similarity(content, $2) * (0.5 + 0.5 * importance) AS rank
        FROM warm_tier
        WHERE agent_id = $1
+         AND namespace = $4
          AND content ILIKE $3
          ${timeFilter}
        ORDER BY rank DESC
@@ -689,6 +713,7 @@ Ranking (numbers only):`;
     limit: number,
     after?: Date,
     before?: Date,
+    namespace: string = DEFAULT_NAMESPACE,
   ): Promise<QueryResult[]> {
     if (!this.embeddingsEnabled) {
       throw new Error('Semantic search requires an embedding provider — set EMBEDDING_PROVIDER');
@@ -697,8 +722,8 @@ Ranking (numbers only):`;
     const queryEmbedding = await this.embedder.embed(searchText);
     const vectorLiteral = `[${queryEmbedding.join(',')}]`;
 
-    const params: SqlParam[] =[agentId, vectorLiteral];
-    const timeFilter = this.buildTimeFilter(after, before, 3);
+    const params: SqlParam[] =[agentId, vectorLiteral, namespace];
+    const timeFilter = this.buildTimeFilter(after, before, 4);
     if (after) params.push(after);
     if (before) params.push(before);
     params.push(limit);
@@ -709,6 +734,7 @@ Ranking (numbers only):`;
               (1 - (embedding <=> $2::halfvec)) * (0.5 + 0.5 * importance) AS rank
        FROM warm_tier
        WHERE agent_id = $1
+         AND namespace = $3
          AND embedding IS NOT NULL
          ${timeFilter}
        ORDER BY embedding <=> $2::halfvec
@@ -727,17 +753,18 @@ Ranking (numbers only):`;
     limit: number,
     after?: Date,
     before?: Date,
+    namespace: string = DEFAULT_NAMESPACE,
   ): Promise<QueryResult[]> {
     // If embeddings are not enabled, fall back to keyword-only
     if (!this.embeddingsEnabled) {
-      return this.queryKeyword(agentId, searchText, limit, after, before);
+      return this.queryKeyword(agentId, searchText, limit, after, before, namespace);
     }
 
     // Fetch more candidates for fusion — diminishing returns above ~60 per source
     const candidateLimit = Math.min(Math.max(limit * 2, 20), 60);
     const [keywordResults, semanticResults] = await Promise.all([
-      this.queryKeyword(agentId, searchText, candidateLimit, after, before),
-      this.querySemantic(agentId, searchText, candidateLimit, after, before),
+      this.queryKeyword(agentId, searchText, candidateLimit, after, before, namespace),
+      this.querySemantic(agentId, searchText, candidateLimit, after, before, namespace),
     ]);
 
     // Reciprocal rank fusion (k=60 is standard)
@@ -882,9 +909,10 @@ Ranking (numbers only):`;
    * @param agentId  Tenant identifier
    * @param mode     Override the configured consolidation mode for this run
    */
-  async consolidate(agentId: string, mode?: ConsolidationMode): Promise<ConsolidateResult & { batchesProcessed?: number }> {
+  async consolidate(agentId: string, mode?: ConsolidationMode, opts?: ConsolidateOptions): Promise<ConsolidateResult & { batchesProcessed?: number }> {
     this.assertAgentId(agentId);
 
+    const ns = resolveNamespace(opts?.namespace);
     const resolvedMode = mode ?? this.config.consolidationMode;
     const INNER_BATCH_SIZE = Math.max(1, this.config.consolidationInnerBatchSize ?? 50);
     const outerCap = this.config.consolidationBatchSize;
@@ -893,7 +921,9 @@ Ranking (numbers only):`;
     // We cannot use pg_advisory_xact_lock here because each inner batch commits
     // its own transaction — a transaction-level lock would be released on each
     // COMMIT, allowing interleaving between concurrent callers.
-    const lockKey = `memforge:consolidate:${agentId}`;
+    // The lock key includes namespace so concurrent consolidations in different
+    // namespaces can proceed in parallel.
+    const lockKey = `memforge:consolidate:${agentId}:${ns}`;
     const lockClient = await this.pool.connect();
     // Retrieve the numeric lock ID from Postgres so we use the same hashtext()
     // result for both the lock and unlock calls.
@@ -913,16 +943,16 @@ Ranking (numbers only):`;
       // totals are written on completion. This matches the existing schema
       // which has one log row per run, not one per inner batch.
       const logRow = await lockClient.query<{ id: bigint }>(
-        `INSERT INTO consolidation_log (agent_id, metadata) VALUES ($1, $2) RETURNING id`,
-        [agentId, JSON.stringify({ consolidation_mode: resolvedMode })],
+        `INSERT INTO consolidation_log (agent_id, metadata, namespace) VALUES ($1, $2, $3) RETURNING id`,
+        [agentId, JSON.stringify({ consolidation_mode: resolvedMode }), ns],
       );
       runId = logRow.rows[0]!.id;
 
       // Determine upfront how many rows are available (for progress logging).
       // This is a snapshot — SKIP LOCKED in each inner batch handles races.
       const countRow = await lockClient.query<{ n: string }>(
-        `SELECT count(*) AS n FROM hot_tier WHERE agent_id = $1`,
-        [agentId],
+        `SELECT count(*) AS n FROM hot_tier WHERE agent_id = $1 AND namespace = $2`,
+        [agentId, ns],
       );
       const availableRows = Math.min(parseInt(countRow.rows[0]!.n, 10), outerCap);
 
@@ -966,11 +996,11 @@ Ranking (numbers only):`;
           }>(
             `SELECT id, content, metadata, created_at
              FROM hot_tier
-             WHERE agent_id = $1
+             WHERE agent_id = $1 AND namespace = $2
              ORDER BY created_at ASC
-             LIMIT $2
+             LIMIT $3
              FOR UPDATE SKIP LOCKED`,
-            [agentId, INNER_BATCH_SIZE],
+            [agentId, ns, INNER_BATCH_SIZE],
           );
 
           if (hotRows.rows.length === 0) {
@@ -1078,11 +1108,12 @@ Ranking (numbers only):`;
 
           const summaryText = summary ? summary.summary : null;
 
+          // Warm rows inherit the namespace of the hot rows they were consolidated from.
           const warmRow = await client.query<{ id: bigint }>(
-            `INSERT INTO warm_tier (agent_id, content, summary, source_hot_ids, metadata, embedding, time_start, time_end, outcome_type)
-             VALUES ($1, $2, $9, $3, $4, $5::halfvec, $6, $7, $8)
+            `INSERT INTO warm_tier (agent_id, content, summary, source_hot_ids, metadata, embedding, time_start, time_end, outcome_type, namespace)
+             VALUES ($1, $2, $9, $3, $4, $5::halfvec, $6, $7, $8, $10)
              RETURNING id`,
-            [agentId, finalContent, batchIds, JSON.stringify(metadata), vectorLiteral, oldest, newest, dominantOutcome, summaryText],
+            [agentId, finalContent, batchIds, JSON.stringify(metadata), vectorLiteral, oldest, newest, dominantOutcome, summaryText, ns],
           );
           const warmRowId = warmRow.rows[0]!.id;
 
@@ -1184,8 +1215,8 @@ Ranking (numbers only):`;
           // Delete this inner batch's hot-tier rows by explicit ID — safe even
           // if the outer-cap count snapshot was stale; we only delete what we read.
           await client.query(
-            `DELETE FROM hot_tier WHERE agent_id = $1 AND id = ANY($2)`,
-            [agentId, batchIds],
+            `DELETE FROM hot_tier WHERE agent_id = $1 AND id = ANY($2) AND namespace = $3`,
+            [agentId, batchIds, ns],
           );
 
           await client.query('COMMIT');
@@ -1270,11 +1301,11 @@ Ranking (numbers only):`;
       // Advisory lock — serializes concurrent clear operations for the same agent
       await client.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [`memforge:clear:${agentId}`]);
 
-      // Archive hot_tier rows
+      // Archive hot_tier rows — namespace propagates from source rows
       const hotResult = await client.query<{ count: string }>(
         `WITH moved AS (
-           INSERT INTO cold_tier (agent_id, source_table, source_id, content, metadata, original_created_at)
-           SELECT agent_id, 'hot_tier', id, content, metadata, created_at
+           INSERT INTO cold_tier (agent_id, source_table, source_id, content, metadata, original_created_at, namespace)
+           SELECT agent_id, 'hot_tier', id, content, metadata, created_at, namespace
            FROM hot_tier
            WHERE agent_id = $1
            RETURNING source_id
@@ -1285,11 +1316,11 @@ Ranking (numbers only):`;
 
       await client.query(`DELETE FROM hot_tier WHERE agent_id = $1`, [agentId]);
 
-      // Archive warm_tier rows
+      // Archive warm_tier rows — namespace propagates from source rows
       const warmResult = await client.query<{ count: string }>(
         `WITH moved AS (
-           INSERT INTO cold_tier (agent_id, source_table, source_id, content, metadata, original_created_at)
-           SELECT agent_id, 'warm_tier', id, content, metadata, consolidated_at
+           INSERT INTO cold_tier (agent_id, source_table, source_id, content, metadata, original_created_at, namespace)
+           SELECT agent_id, 'warm_tier', id, content, metadata, consolidated_at, namespace
            FROM warm_tier
            WHERE agent_id = $1
            RETURNING source_id
@@ -1913,26 +1944,28 @@ Ranking (numbers only):`;
    * can record which IDs were removed. A single bulk DELETE is used — batching is
    * a follow-up if prune volumes grow large enough to matter.
    */
-  async pruneColdTier(agentId: string): Promise<{ pruned: number }> {
+  async pruneColdTier(agentId: string, namespace?: string): Promise<{ pruned: number }> {
     this.assertAgentId(agentId);
 
     const retentionDays = this.config.sleepCycle.coldRetentionDays ?? 0;
     if (!retentionDays) return { pruned: 0 };
 
+    const ns = resolveNamespace(namespace);
+
     const { rows } = await this.pool.query<{ id: bigint }>(
-      `DELETE FROM cold_tier WHERE agent_id = $1
-         AND archived_at < now() - interval '1 day' * $2
+      `DELETE FROM cold_tier WHERE agent_id = $1 AND namespace = $2
+         AND archived_at < now() - interval '1 day' * $3
        RETURNING id`,
-      [agentId, retentionDays],
+      [agentId, ns, retentionDays],
     );
     const pruned = rows.length;
 
-    log.info({ agentId, pruned, retentionDays }, 'cold tier retention prune complete');
+    log.info({ agentId, namespace: ns, pruned, retentionDays }, 'cold tier retention prune complete');
 
     if (this.audit && pruned > 0) {
       void this.audit.recordBatch(
         agentId, 'cold_tier', 'delete',
-        { pruned, retentionDays, deleted_ids: rows.map((r) => String(r.id)) },
+        { pruned, retentionDays, namespace: ns, deleted_ids: rows.map((r) => String(r.id)) },
         'sleep_cycle',
       ).catch((err: unknown) => log.error({ err }, 'cold tier prune audit failed'));
     }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -14,6 +14,21 @@ import { getLogger } from './logger.js';
 
 const log = getLogger('schemas');
 
+// ─── Namespace Validator ────────────────────────────────────────────────────
+// Safe-URL-ish token: lowercase letters, digits, underscore, hyphen.
+// Min length 1, max 128. Leading character must be alphanumeric.
+// Examples: 'default', 'frontend', 'ops-team', 'project_x42'
+export const NamespaceSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-z0-9][a-z0-9_-]*$/i, 'namespace must start with a letter or digit and contain only letters, digits, underscores, or hyphens');
+
+// Request schema helpers for methods that accept an optional namespace
+export const NamespacedRequestSchema = z.object({
+  namespace: NamespaceSchema.optional(),
+});
+
 // ─── LLM Response Schemas ───────────────────────────────────────────────────
 
 export const ConsolidationSummarySchema = z.object({

--- a/src/sleep-cycle.ts
+++ b/src/sleep-cycle.ts
@@ -341,16 +341,18 @@ export class SleepCycleEngine {
       [agentId],
     );
 
-    // Evict low-importance memories to cold tier (graduated memories are protected)
+    // Evict low-importance memories to cold tier (graduated memories are protected).
+    // Namespace propagates from the source warm_tier row so cold_tier retains
+    // the correct partition for later targeted pruning.
     const evictResult = await this.pool.query<{ count: string }>(
       `WITH evictable AS (
-         SELECT id, content, metadata, consolidated_at
+         SELECT id, content, metadata, consolidated_at, namespace
          FROM warm_tier
          WHERE agent_id = $1 AND importance < $2 AND NOT graduated
        ),
        moved AS (
-         INSERT INTO cold_tier (agent_id, source_table, source_id, content, metadata, original_created_at)
-         SELECT $1, 'warm_tier', e.id, e.content, e.metadata, e.consolidated_at
+         INSERT INTO cold_tier (agent_id, source_table, source_id, content, metadata, original_created_at, namespace)
+         SELECT $1, 'warm_tier', e.id, e.content, e.metadata, e.consolidated_at, e.namespace
          FROM evictable e
          RETURNING source_id
        ),
@@ -389,8 +391,8 @@ export class SleepCycleEngine {
 
   private async reviseMemory(agentId: string, warmTierId: bigint): Promise<number> {
     // Gather the memory and its context
-    const memory = await this.pool.query<{ content: string; metadata: Record<string, unknown>; importance: number }>(
-      `SELECT content, metadata, importance FROM warm_tier WHERE id = $1 AND agent_id = $2`,
+    const memory = await this.pool.query<{ content: string; metadata: Record<string, unknown>; importance: number; namespace: string }>(
+      `SELECT content, metadata, importance, namespace FROM warm_tier WHERE id = $1 AND agent_id = $2`,
       [warmTierId, agentId],
     );
     if (memory.rows.length === 0) return 0;
@@ -491,12 +493,12 @@ ${wrapUserContent('related_memories', relatedList || 'None')}`;
     );
     const nextRevision = (revNum.rows[0]?.max ?? 0) + 1;
 
-    // Log the revision
+    // Log the revision — namespace inherited from the warm_tier row being revised
     const revisionResult = await this.pool.query<{ id: bigint }>(
-      `INSERT INTO memory_revisions (agent_id, warm_tier_id, revision_number, previous_content, new_content, revision_type, reason, delta_summary, confidence, model_used)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      `INSERT INTO memory_revisions (agent_id, warm_tier_id, revision_number, previous_content, new_content, revision_type, reason, delta_summary, confidence, model_used, namespace)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING id`,
-      [agentId, warmTierId, nextRevision, row.content, revisedContent, action as RevisionType, reason, deltaSummary, confidence, this.llm.model],
+      [agentId, warmTierId, nextRevision, row.content, revisedContent, action as RevisionType, reason, deltaSummary, confidence, this.llm.model, row.namespace],
     );
 
     // Update the warm tier row

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface HotRow {
   content: string;
   metadata: Record<string, unknown>;
   created_at: Date;
+  namespace: string;
 }
 
 export interface AddResult {
@@ -43,6 +44,7 @@ export interface WarmRow {
   time_end: Date | null;
   access_count: number;
   last_accessed: Date | null;
+  namespace: string;
   /** Full-text search rank (present only in query results) */
   rank?: number;
 }
@@ -79,6 +81,8 @@ export interface QueryOptions {
   decayRate?: number;
   /** Token budget — return results fitting within this many tokens (estimate: content.length/4). */
   maxTokens?: number;
+  /** Namespace to search within (default: 'default') */
+  namespace?: string;
 }
 
 // ─── Timeline ────────────────────────────────────────────────────────────────
@@ -104,6 +108,19 @@ export interface ConsolidateResult {
   warm_rows_created: number;
   consolidation_mode: ConsolidationMode;
   status: 'complete' | 'failed';
+}
+
+/** Options for consolidate() — namespace scopes which hot rows are processed. */
+export interface ConsolidateOptions {
+  namespace?: string;
+}
+
+/** Options for add() */
+export interface AddOptions {
+  metadata?: Record<string, unknown>;
+  outcomeType?: OutcomeType;
+  hints?: MemoryHints;
+  namespace?: string;
 }
 
 // ─── Knowledge Graph ─────────────────────────────────────────────────────────
@@ -181,6 +198,7 @@ export interface Reflection {
   source_reflection_ids: bigint[];
   metadata: Record<string, unknown>;
   created_at: Date;
+  namespace: string;
 }
 
 export interface ReflectionResult {
@@ -216,6 +234,7 @@ export interface Procedure {
   active: boolean;
   metadata: Record<string, unknown>;
   created_at: Date;
+  namespace: string;
 }
 
 // ─── Memory Revision Engine ──────────────────────────────────────────────────
@@ -262,6 +281,7 @@ export interface MemoryRevision {
   confidence: number;
   model_used: string;
   created_at: Date;
+  namespace: string;
 }
 
 export interface SleepCycleResult {

--- a/tests/memory-namespaces.test.ts
+++ b/tests/memory-namespaces.test.ts
@@ -1,0 +1,358 @@
+// MemForge — Memory Namespace Tests (Sprint C.1 / Phase 2 / Issue #16)
+//
+// Tests the backend namespace partitioning added in v3.1. Namespaces scope
+// memories to a domain — 'frontend', 'backend', 'ops' — without duplicating
+// the knowledge graph (entities and relationships stay agent-scoped).
+//
+// Requires: DATABASE_URL pointing to a test database with schema applied.
+//
+// Run: node --import tsx/esm --test tests/memory-namespaces.test.ts
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { Pool } from 'pg';
+
+const { MemoryManager } = await import('../src/memory-manager.js');
+const { NoOpEmbeddingProvider } = await import('../src/embedding.js');
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+if (!DATABASE_URL) {
+  console.error('[test] DATABASE_URL is required — set it to a test database');
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString: DATABASE_URL });
+
+const AGENT_NS = 'test-ns-isolation';
+const AGENT_CONSOLIDATE = 'test-ns-consolidation';
+const AGENT_ENTITY = 'test-ns-entity-reuse';
+
+const ALL_AGENTS = [AGENT_NS, AGENT_CONSOLIDATE, AGENT_ENTITY];
+
+async function ensureAgent(agentId: string): Promise<void> {
+  await pool.query(
+    `INSERT INTO agents (id, metadata) VALUES ($1, '{}') ON CONFLICT (id) DO NOTHING`,
+    [agentId],
+  );
+}
+
+async function cleanupAgent(agentId: string): Promise<void> {
+  await pool.query(`DELETE FROM memory_revisions WHERE agent_id = $1`, [agentId]);
+  await pool.query(`DELETE FROM retrieval_log WHERE agent_id = $1`, [agentId]);
+  await pool.query(`DELETE FROM procedures WHERE agent_id = $1`, [agentId]);
+  await pool.query(`DELETE FROM reflections WHERE agent_id = $1`, [agentId]);
+  await pool.query(`DELETE FROM warm_tier_entities WHERE warm_tier_id IN (SELECT id FROM warm_tier WHERE agent_id = $1)`, [agentId]);
+  await pool.query(`DELETE FROM relationships WHERE agent_id = $1`, [agentId]);
+  await pool.query(`DELETE FROM entities WHERE agent_id = $1`, [agentId]);
+  await pool.query(`DELETE FROM cold_tier WHERE agent_id = $1`, [agentId]);
+  await pool.query(`DELETE FROM consolidation_log WHERE agent_id = $1`, [agentId]);
+  await pool.query(`DELETE FROM warm_tier WHERE agent_id = $1`, [agentId]);
+  await pool.query(`DELETE FROM hot_tier WHERE agent_id = $1`, [agentId]);
+  await pool.query(`DELETE FROM agents WHERE id = $1`, [agentId]);
+}
+
+async function cleanupAll(): Promise<void> {
+  await Promise.all(ALL_AGENTS.map(cleanupAgent));
+}
+
+function makeManager(): InstanceType<typeof MemoryManager> {
+  return new MemoryManager({
+    databaseUrl: DATABASE_URL!,
+    consolidationBatchSize: 500,
+    consolidationInnerBatchSize: 50,
+    consolidationThreshold: 1,
+    autoRegisterAgents: false,
+    consolidationMode: 'concat',
+    temporalDecayRate: 0,
+    embeddingProvider: new NoOpEmbeddingProvider(),
+    llmProvider: null,
+    sleepCycle: {
+      tokenBudget: 100_000,
+      evictionThreshold: 0.1,
+      revisionThreshold: 0.4,
+      includeReflection: false,
+      weights: { recency: 0.25, frequency: 0.20, centrality: 0.20, reflection: 0.15, stability: 0.20 },
+    },
+  });
+}
+
+// ─── Test 1: Default namespace is 'default' ──────────────────────────────────
+//
+// add() without a namespace param stores in 'default'.
+// query() without a namespace param retrieves from 'default' only.
+
+describe('namespace: default namespace is "default"', () => {
+  const manager = makeManager();
+
+  before(async () => {
+    await cleanupAgent(AGENT_NS);
+    await ensureAgent(AGENT_NS);
+  });
+
+  after(() => cleanupAgent(AGENT_NS));
+
+  it('add without namespace stores in default', async () => {
+    await manager.add(AGENT_NS, 'content stored in default namespace');
+
+    const { rows } = await pool.query<{ namespace: string }>(
+      `SELECT namespace FROM hot_tier WHERE agent_id = $1`,
+      [AGENT_NS],
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!.namespace, 'default');
+  });
+
+  it('query without namespace retrieves only default namespace rows', async () => {
+    // Consolidate so there is something in warm_tier
+    await manager.consolidate(AGENT_NS);
+
+    const results = await manager.query(AGENT_NS, { q: 'default namespace' });
+
+    // All results must come from warm_tier rows with namespace='default'
+    for (const r of results) {
+      const { rows } = await pool.query<{ namespace: string }>(
+        `SELECT namespace FROM warm_tier WHERE id = $1`,
+        [r.id],
+      );
+      assert.equal(rows[0]!.namespace, 'default', `warm row ${r.id} must have namespace=default`);
+    }
+  });
+});
+
+// ─── Test 2: Namespace isolation ─────────────────────────────────────────────
+//
+// Rows in namespace 'a' must not appear in queries for namespace 'b' and vice versa.
+
+describe('namespace: isolation between namespaces', () => {
+  const manager = makeManager();
+
+  before(async () => {
+    await cleanupAgent(AGENT_NS);
+    await ensureAgent(AGENT_NS);
+
+    // Insert one hot row per namespace then consolidate each
+    await manager.add(AGENT_NS, 'memory about frontend work', {}, 'neutral', undefined, 'frontend');
+    await manager.consolidate(AGENT_NS, undefined, { namespace: 'frontend' });
+
+    await manager.add(AGENT_NS, 'memory about backend database', {}, 'neutral', undefined, 'backend');
+    await manager.consolidate(AGENT_NS, undefined, { namespace: 'backend' });
+  });
+
+  after(() => cleanupAgent(AGENT_NS));
+
+  it('query namespace=frontend returns only frontend rows', async () => {
+    const results = await manager.query(AGENT_NS, { q: 'memory', namespace: 'frontend' });
+
+    assert.ok(results.length > 0, 'expected at least one result');
+    for (const r of results) {
+      const { rows } = await pool.query<{ namespace: string }>(
+        `SELECT namespace FROM warm_tier WHERE id = $1`,
+        [r.id],
+      );
+      assert.equal(rows[0]!.namespace, 'frontend');
+    }
+  });
+
+  it('query namespace=backend returns only backend rows', async () => {
+    const results = await manager.query(AGENT_NS, { q: 'memory', namespace: 'backend' });
+
+    assert.ok(results.length > 0, 'expected at least one result');
+    for (const r of results) {
+      const { rows } = await pool.query<{ namespace: string }>(
+        `SELECT namespace FROM warm_tier WHERE id = $1`,
+        [r.id],
+      );
+      assert.equal(rows[0]!.namespace, 'backend');
+    }
+  });
+
+  it('frontend query does not see backend rows', async () => {
+    const results = await manager.query(AGENT_NS, { q: 'database', namespace: 'frontend' });
+    // 'database' only appears in the backend row — frontend should return nothing
+    assert.equal(results.length, 0, 'frontend query must not see backend rows');
+  });
+});
+
+// ─── Test 3: Consolidation is namespace-scoped ───────────────────────────────
+//
+// consolidate(namespace='a') moves only hot rows in 'a' to warm; 'b' stays hot.
+// The resulting warm rows carry namespace='a'.
+
+describe('namespace: consolidation is namespace-scoped', () => {
+  const manager = makeManager();
+
+  before(async () => {
+    await cleanupAgent(AGENT_CONSOLIDATE);
+    await ensureAgent(AGENT_CONSOLIDATE);
+
+    // Insert hot rows in two namespaces — explicit timestamps ensure order
+    const t1 = new Date('2026-01-01T10:00:00Z');
+    const t2 = new Date('2026-01-01T10:01:00Z');
+    await pool.query(
+      `INSERT INTO hot_tier (agent_id, content, metadata, content_hash, namespace, created_at)
+       VALUES ($1, $2, '{}', $3, $4, $5)`,
+      [AGENT_CONSOLIDATE, 'hot row for namespace alpha', 'hash-alpha-1', 'alpha', t1],
+    );
+    await pool.query(
+      `INSERT INTO hot_tier (agent_id, content, metadata, content_hash, namespace, created_at)
+       VALUES ($1, $2, '{}', $3, $4, $5)`,
+      [AGENT_CONSOLIDATE, 'hot row for namespace beta', 'hash-beta-1', 'beta', t2],
+    );
+  });
+
+  after(() => cleanupAgent(AGENT_CONSOLIDATE));
+
+  it('consolidating alpha moves only alpha hot rows to warm', async () => {
+    const result = await manager.consolidate(AGENT_CONSOLIDATE, undefined, { namespace: 'alpha' });
+
+    assert.equal(result.hot_rows_processed, 1, 'only alpha hot row should be processed');
+    assert.equal(result.warm_rows_created, 1);
+
+    // alpha hot row is gone
+    const { rows: alphaHot } = await pool.query<{ count: string }>(
+      `SELECT count(*) AS count FROM hot_tier WHERE agent_id = $1 AND namespace = 'alpha'`,
+      [AGENT_CONSOLIDATE],
+    );
+    assert.equal(parseInt(alphaHot[0]!.count, 10), 0, 'alpha hot rows should be gone after consolidation');
+
+    // beta hot row remains
+    const { rows: betaHot } = await pool.query<{ count: string }>(
+      `SELECT count(*) AS count FROM hot_tier WHERE agent_id = $1 AND namespace = 'beta'`,
+      [AGENT_CONSOLIDATE],
+    );
+    assert.equal(parseInt(betaHot[0]!.count, 10), 1, 'beta hot rows must remain untouched');
+  });
+
+  it('consolidated warm rows carry namespace=alpha', async () => {
+    const { rows } = await pool.query<{ namespace: string }>(
+      `SELECT namespace FROM warm_tier WHERE agent_id = $1`,
+      [AGENT_CONSOLIDATE],
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!.namespace, 'alpha', 'warm row must inherit namespace from the hot rows');
+  });
+});
+
+// ─── Test 4: Cross-namespace entity reuse ────────────────────────────────────
+//
+// Entities live on agent_id, not on namespace. Adding warm rows mentioning
+// "User Sarah" in two namespaces should upsert to the same entity row —
+// the knowledge graph is shared across namespaces.
+
+describe('namespace: cross-namespace entity reuse', () => {
+  const manager = makeManager();
+
+  before(async () => {
+    await cleanupAgent(AGENT_ENTITY);
+    await ensureAgent(AGENT_ENTITY);
+
+    // Insert an entity and two warm rows (one per namespace) referencing it
+    const { rows: entityRows } = await pool.query<{ id: bigint }>(
+      `INSERT INTO entities (agent_id, name, entity_type) VALUES ($1, 'User Sarah', 'person')
+       ON CONFLICT (agent_id, name) DO UPDATE SET mention_count = entities.mention_count + 1
+       RETURNING id`,
+      [AGENT_ENTITY],
+    );
+    const entityId = entityRows[0]!.id;
+
+    // Warm row in namespace 'ops'
+    const { rows: warmOps } = await pool.query<{ id: bigint }>(
+      `INSERT INTO warm_tier (agent_id, content, source_hot_ids, metadata, namespace)
+       VALUES ($1, 'Sarah manages ops deployments', '{}', '{}', 'ops')
+       RETURNING id`,
+      [AGENT_ENTITY],
+    );
+    await pool.query(
+      `INSERT INTO warm_tier_entities (warm_tier_id, entity_id) VALUES ($1, $2)`,
+      [warmOps[0]!.id, entityId],
+    );
+
+    // Warm row in namespace 'engineering'
+    const { rows: warmEng } = await pool.query<{ id: bigint }>(
+      `INSERT INTO warm_tier (agent_id, content, source_hot_ids, metadata, namespace)
+       VALUES ($1, 'Sarah reviews engineering PRs', '{}', '{}', 'engineering')
+       RETURNING id`,
+      [AGENT_ENTITY],
+    );
+    await pool.query(
+      `INSERT INTO warm_tier_entities (warm_tier_id, entity_id) VALUES ($1, $2)`,
+      [warmEng[0]!.id, entityId],
+    );
+  });
+
+  after(() => cleanupAgent(AGENT_ENTITY));
+
+  it('both namespace rows link to the same entity row', async () => {
+    // Entities are not namespace-scoped — one row for "User Sarah" shared across namespaces.
+    // This is Design A: the knowledge graph is agent-scoped, not namespace-scoped.
+    // Warm rows in different namespaces reference the same entity via warm_tier_entities.
+    const { rows: entityRows } = await pool.query<{ id: bigint }>(
+      `SELECT id FROM entities WHERE agent_id = $1 AND name = 'User Sarah'`,
+      [AGENT_ENTITY],
+    );
+    assert.equal(entityRows.length, 1, 'exactly one entity row regardless of namespaces');
+
+    const entityId = entityRows[0]!.id;
+
+    // Both warm rows should link to this single entity
+    const { rows: junctionRows } = await pool.query<{ warm_tier_id: bigint; namespace: string }>(
+      `SELECT wte.warm_tier_id, w.namespace
+       FROM warm_tier_entities wte
+       JOIN warm_tier w ON w.id = wte.warm_tier_id
+       WHERE wte.entity_id = $1 AND w.agent_id = $2
+       ORDER BY w.namespace`,
+      [entityId, AGENT_ENTITY],
+    );
+
+    assert.equal(junctionRows.length, 2, 'both warm rows must link to the single entity');
+    const namespaces = junctionRows.map((r) => r.namespace).sort();
+    assert.deepEqual(namespaces, ['engineering', 'ops'], 'junction covers both namespaces');
+  });
+});
+
+// ─── Test 5: Invalid namespace is rejected ───────────────────────────────────
+//
+// Namespaces must match /^[a-z0-9][a-z0-9_-]*$/i. Values with spaces, leading
+// hyphens, or empty strings must be rejected at the schema-validation layer.
+
+describe('namespace: invalid namespace rejected at validation', () => {
+  const manager = makeManager();
+
+  before(async () => {
+    await cleanupAgent(AGENT_NS);
+    await ensureAgent(AGENT_NS);
+  });
+
+  after(() => cleanupAgent(AGENT_NS));
+
+  it('namespace with spaces throws TypeError from add()', async () => {
+    await assert.rejects(
+      () => manager.add(AGENT_NS, 'some content', {}, 'neutral', undefined, 'Foo Bar'),
+      (err: unknown) => err instanceof TypeError,
+    );
+  });
+
+  it('namespace with leading hyphen throws TypeError from query()', async () => {
+    await assert.rejects(
+      () => manager.query(AGENT_NS, { q: 'search', namespace: '-invalid' }),
+      (err: unknown) => err instanceof TypeError,
+    );
+  });
+
+  it('empty namespace throws TypeError from consolidate()', async () => {
+    await assert.rejects(
+      () => manager.consolidate(AGENT_NS, undefined, { namespace: '' }),
+      (err: unknown) => err instanceof TypeError,
+    );
+  });
+
+  it('namespace exceeding 128 chars throws TypeError from add()', async () => {
+    const longNs = 'a'.repeat(129);
+    await assert.rejects(
+      () => manager.add(AGENT_NS, 'some content', {}, 'neutral', undefined, longNs),
+      (err: unknown) => err instanceof TypeError,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Backend half of memory namespaces (#16). Partition memories by an opt-in \`namespace\` so agents with broad responsibilities can focus retrieval on one domain at a time. **Opt-in**: default namespace is \`'default'\`, existing callers/deployments see no behavior change.

Public surface (HTTP, MCP tools, SDK, OpenAPI) ships in Sprint C.2.

## Changes

**Schema** (\`schema/migration-v3.1.sql\` + mirrored into canonical \`schema/schema.sql\`):
- \`namespace TEXT NOT NULL DEFAULT 'default'\` on 8 memory tables: \`hot_tier\`, \`warm_tier\`, \`cold_tier\`, \`reflections\`, \`procedures\`, \`consolidation_log\`, \`retrieval_log\`, \`memory_revisions\`.
- Composite \`(agent_id, namespace)\` index on each.
- Migration is safely re-runnable via DO blocks + \`IF NOT EXISTS\`.

**Knowledge graph scoping decision** (documented inline in the migration): entities / relationships / \`warm_tier_entities\` stay agent-scoped, NOT namespace-scoped. A single entity ("User Sarah") can appear across namespaces for the same agent; duplicating per namespace would fragment the graph. Test 4 verifies this — two warm rows in different namespaces both link to the same entity row.

**MemoryManager** (\`src/memory-manager.ts\`, \`src/sleep-cycle.ts\`):
- Optional \`namespace?\` on \`add\` / \`query\` / \`consolidate\` / \`pruneColdTier\`.
- All INSERT/SELECT/UPDATE/DELETE on the 8 tables now include the namespace.
- Consolidation advisory lock key now includes namespace — allows parallel consolidations across namespaces for the same agent while still serializing within a single \`(agent, namespace)\`.
- Sleep cycle eviction propagates namespace from \`warm_tier\` to \`cold_tier\`; revisions inherit their warm row's namespace.

**Validation** (\`src/schemas.ts\`, \`src/types.ts\`):
- \`NamespaceSchema\`: \`z.string().min(1).max(128).regex(/^[a-z0-9][a-z0-9_-]*$/i)\` — safe-URL token.
- Invalid namespace inputs rejected before any SQL is issued.

## Tests (\`tests/memory-namespaces.test.ts\`, 358 lines)

1. Default namespace is \`'default'\` (backward compat).
2. Namespace isolation — \`frontend\` rows invisible to \`backend\` queries for same agent.
3. Consolidation is namespace-scoped end-to-end.
4. Cross-namespace entity reuse (knowledge graph agent-scoped).
5. Invalid namespace rejected pre-SQL ('Foo Bar', '-invalid', '', 129-char string).

All tests use explicit timestamps — no sleeps.

## ROADMAP

First commit (\`docs(roadmap):\`) marks #17 (per-agent scoring weights) as ✅ DONE — shipped in migration-v2.4 (#57) — and notes #16 is in progress.

## Test plan

- [ ] CI \`typecheck\` / \`lint\` / \`build\` pass
- [ ] CI \`test-integration\` (Node 20 + 22) passes — includes the new namespaces suite
- [ ] CI \`test-rls\` still passes — namespace lives *inside* agent tenancy, doesn't affect RLS boundaries
- [ ] Load tests skipped on PR; will run on merge to main

## Follow-up

**Sprint C.2** exposes the namespace argument through HTTP (\`app.ts\`), MCP tools (\`mcp.ts\`, \`tool-definitions.ts\`), TS SDK (\`client.ts\`), and OpenAPI spec.