### PR TITLE
feat(namespaces): propagate namespace through public surfaces (Sprint C.2, #16)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,7 +56,7 @@ All Phase 1 items are implemented:
 
 ### Memory Lifecycle Management
 
-- **Memory namespaces** — Partition memories by domain, project, or context so agents with broad responsibilities maintain focused retrieval ([#16](https://github.com/salishforge/memforge/issues/16)) — *in progress: backend (schema + MemoryManager + tests) in PR #TBD; HTTP/MCP/SDK/OpenAPI surface in follow-up (C.2)*
+- **Memory namespaces** — Partition memories by domain, project, or context so agents with broad responsibilities maintain focused retrieval ([#16](https://github.com/salishforge/memforge/issues/16)) — ✅ DONE: backend in PR #100; HTTP/MCP/TypeScript SDK/OpenAPI/Python SDK surface in this PR (C.2)
 - **Per-agent importance tuning** — Different agents need different memory profiles. A support agent should weight recency; a research agent should weight graph centrality ([#17](https://github.com/salishforge/memforge/issues/17)) — ✅ DONE: shipped in v2.4 migration (#57) — `agents.scoring_weights` JSONB column wired into sleep cycle phase 1
 - **Cold tier search and restoration** — Query archived memories and selectively restore them when context shifts back to old topics ([#14](https://github.com/salishforge/memforge/issues/14))
 

--- a/python/memforge/client.py
+++ b/python/memforge/client.py
@@ -86,6 +86,7 @@ class MemForgeClient:
         metadata: dict[str, Any] | None = None,
         outcome_type: str = "neutral",
         hints: MemoryHints | None = None,
+        namespace: str | None = None,
     ) -> AddResult:
         """Store a memory event in the hot tier."""
         body: dict[str, Any] = {"content": content}
@@ -95,6 +96,8 @@ class MemForgeClient:
             body["outcome_type"] = outcome_type
         if hints:
             body["hints"] = {k: v for k, v in hints.__dict__.items() if v is not None}
+        if namespace:
+            body["namespace"] = namespace
         raw = await self._post(f"/memory/{agent_id}/add", body)
         return AddResult(**{k: raw[k] for k in ("id", "agent_id", "created_at") if k in raw})
 
@@ -109,6 +112,7 @@ class MemForgeClient:
         before: str | None = None,
         decay: float | None = None,
         max_tokens: int | None = None,
+        namespace: str | None = None,
     ) -> list[QueryResult]:
         """Search warm-tier memory."""
         params: dict[str, Any] = {"q": q, "limit": limit}
@@ -122,6 +126,8 @@ class MemForgeClient:
             params["decay"] = decay
         if max_tokens is not None:
             params["max_tokens"] = max_tokens
+        if namespace:
+            params["namespace"] = namespace
         raw = await self._get(f"/memory/{agent_id}/query", params)
         return [QueryResult(**r) for r in raw] if isinstance(raw, list) else []
 
@@ -132,6 +138,7 @@ class MemForgeClient:
         from_date: str | None = None,
         to_date: str | None = None,
         limit: int = 50,
+        namespace: str | None = None,
     ) -> list[dict[str, Any]]:
         """Retrieve memories in chronological order."""
         params: dict[str, Any] = {"limit": limit}
@@ -139,13 +146,17 @@ class MemForgeClient:
             params["from"] = from_date
         if to_date:
             params["to"] = to_date
+        if namespace:
+            params["namespace"] = namespace
         return await self._get(f"/memory/{agent_id}/timeline", params)
 
-    async def consolidate(self, agent_id: str, mode: str | None = None) -> ConsolidateResult:
+    async def consolidate(self, agent_id: str, mode: str | None = None, namespace: str | None = None) -> ConsolidateResult:
         """Trigger hot→warm consolidation."""
         body: dict[str, Any] = {}
         if mode:
             body["mode"] = mode
+        if namespace:
+            body["namespace"] = namespace
         raw = await self._post(f"/memory/{agent_id}/consolidate", body)
         return ConsolidateResult(**raw)
 
@@ -154,9 +165,12 @@ class MemForgeClient:
         raw = await self._post(f"/memory/{agent_id}/clear")
         return ClearResult(**raw)
 
-    async def stats(self, agent_id: str) -> AgentStats:
+    async def stats(self, agent_id: str, namespace: str | None = None) -> AgentStats:
         """Get memory tier statistics."""
-        raw = await self._get(f"/memory/{agent_id}/stats")
+        params: dict[str, Any] = {}
+        if namespace:
+            params["namespace"] = namespace
+        raw = await self._get(f"/memory/{agent_id}/stats", params or None)
         return AgentStats(**raw)
 
     # ── Knowledge Graph ──────────────────────────────────────────────────
@@ -213,7 +227,7 @@ class MemForgeClient:
         revision_threshold: float | None = None,
         include_reflection: bool | None = None,
     ) -> SleepCycleResult:
-        """Run a full sleep cycle."""
+        """Run a full sleep cycle. Agent-wide: processes all namespaces."""
         body: dict[str, Any] = {}
         if token_budget is not None:
             body["tokenBudget"] = token_budget
@@ -223,6 +237,8 @@ class MemForgeClient:
             body["revisionThreshold"] = revision_threshold
         if include_reflection is not None:
             body["includeReflection"] = include_reflection
+        if namespace:
+            body["namespace"] = namespace
         raw = await self._post(f"/memory/{agent_id}/sleep", body)
         return SleepCycleResult(**raw)
 
@@ -231,9 +247,12 @@ class MemForgeClient:
         raw = await self._get(f"/memory/{agent_id}/health")
         return MemoryHealth(**raw)
 
-    async def resume(self, agent_id: str, limit: int = 5) -> ResumeContext:
+    async def resume(self, agent_id: str, limit: int = 5, namespace: str | None = None) -> ResumeContext:
         """Get session resumption context bundle."""
-        raw = await self._get(f"/memory/{agent_id}/resume", {"limit": limit})
+        params: dict[str, Any] = {"limit": limit}
+        if namespace:
+            params["namespace"] = namespace
+        raw = await self._get(f"/memory/{agent_id}/resume", params)
         return ResumeContext(**raw)
 
     # ── Feedback ─────────────────────────────────────────────────────────

--- a/python/memforge/resilient.py
+++ b/python/memforge/resilient.py
@@ -75,9 +75,9 @@ class ResilientMemForgeClient:
             self._handle(e)
             return []
 
-    async def consolidate(self, agent_id: str, mode: str | None = None) -> ConsolidateResult | None:
+    async def consolidate(self, agent_id: str, mode: str | None = None, namespace: str | None = None) -> ConsolidateResult | None:
         try:
-            return await self._client.consolidate(agent_id, mode)
+            return await self._client.consolidate(agent_id, mode, namespace)
         except Exception as e:
             self._handle(e)
             return None
@@ -89,9 +89,9 @@ class ResilientMemForgeClient:
             self._handle(e)
             return None
 
-    async def stats(self, agent_id: str) -> AgentStats | None:
+    async def stats(self, agent_id: str, namespace: str | None = None) -> AgentStats | None:
         try:
-            return await self._client.stats(agent_id)
+            return await self._client.stats(agent_id, namespace)
         except Exception as e:
             self._handle(e)
             return None
@@ -145,9 +145,9 @@ class ResilientMemForgeClient:
             self._handle(e)
             return None
 
-    async def resume(self, agent_id: str, limit: int = 5) -> ResumeContext | None:
+    async def resume(self, agent_id: str, limit: int = 5, namespace: str | None = None) -> ResumeContext | None:
         try:
-            return await self._client.resume(agent_id, limit)
+            return await self._client.resume(agent_id, limit, namespace)
         except Exception as e:
             self._handle(e)
             return None

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ import {
   httpRequestDurationSeconds,
 } from './metrics.js';
 import { bearerAuth, requireScope } from './auth.js';
+import { NamespaceSchema, AddMemorySchema, ConsolidateSchema, SleepSchema } from './schemas.js';
 import {
   cacheGet,
   cacheSet,
@@ -235,12 +236,13 @@ export function createApp(deps: AppDependencies): express.Express {
    * POST /memory/:agentId/add
    */
   app.post('/memory/:agentId/add', requireScope('memforge:write'), async (req: Request, res: Response) => {
-    const { content, metadata, outcome_type, hints } = req.body as {
-      content?: string;
-      metadata?: Record<string, unknown>;
-      outcome_type?: string;
-      hints?: Record<string, unknown>;
-    };
+    const parsed = AddMemorySchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      const msg = parsed.error.issues[0];
+      fail(res, 400, msg?.path[0] === 'namespace' ? `Invalid namespace: ${msg.message}` : `"content" (string) is required`);
+      return;
+    }
+    const { content, metadata, outcome_type, hints, namespace } = parsed.data;
 
     if (!content || typeof content !== 'string') {
       fail(res, 400, '"content" (string) is required');
@@ -269,7 +271,7 @@ export function createApp(deps: AppDependencies): express.Express {
     };
 
     try {
-      const result = await manager.add(getAgentId(req), storeContent, enrichedMetadata, resolvedOutcome as 'error' | 'success' | 'decision' | 'observation' | 'neutral', hints as import('./types.js').MemoryHints | undefined);
+      const result = await manager.add(getAgentId(req), storeContent, enrichedMetadata, resolvedOutcome as 'error' | 'success' | 'decision' | 'observation' | 'neutral', hints as import('./types.js').MemoryHints | undefined, namespace);
       void invalidateAgent(getAgentId(req));
       ok(res, {
         ...result,
@@ -300,6 +302,7 @@ export function createApp(deps: AppDependencies): express.Express {
     const before = req.query['before'];
     const decay = req.query['decay'];
     const maxTokens = req.query['max_tokens'];
+    const rawNamespace = req.query['namespace'];
 
     if (!q || typeof q !== 'string') {
       fail(res, 400, '"q" query param (string) is required');
@@ -340,6 +343,16 @@ export function createApp(deps: AppDependencies): express.Express {
       return;
     }
 
+    let namespace: string | undefined;
+    if (rawNamespace !== undefined) {
+      const nsResult = NamespaceSchema.safeParse(rawNamespace);
+      if (!nsResult.success) {
+        fail(res, 400, `Invalid namespace: ${nsResult.error.issues[0]?.message ?? 'validation failed'}`);
+        return;
+      }
+      namespace = nsResult.data;
+    }
+
     let agentId: string;
     try {
       agentId = getAgentId(req);
@@ -349,7 +362,7 @@ export function createApp(deps: AppDependencies): express.Express {
     }
 
     // Cache key includes all query parameters (including max_tokens to prevent budget mismatch)
-    const cacheKeySuffix = `${mode ?? 'auto'}:${after ?? ''}:${before ?? ''}:${decay ?? ''}:${maxTokensNum ?? ''}`;
+    const cacheKeySuffix = `${mode ?? 'auto'}:${after ?? ''}:${before ?? ''}:${decay ?? ''}:${maxTokensNum ?? ''}:${namespace ?? ''}`;
     const key = searchKey(agentId, `${q}:${cacheKeySuffix}`, limitNum);
     const cached = await cacheGet(key);
     if (cached !== null) {
@@ -369,6 +382,7 @@ export function createApp(deps: AppDependencies): express.Express {
         before: beforeDate,
         decayRate,
         maxTokens: maxTokensNum,
+        namespace,
       });
       void cacheSet(key, results, 'search');
       ok(res, results);
@@ -384,6 +398,7 @@ export function createApp(deps: AppDependencies): express.Express {
     const from = req.query['from'];
     const to = req.query['to'];
     const limit = req.query['limit'];
+    const rawNamespace = req.query['namespace'];
 
     const fromDate = from ? new Date(from as string) : undefined;
     const toDate = to ? new Date(to as string) : undefined;
@@ -403,6 +418,16 @@ export function createApp(deps: AppDependencies): express.Express {
       return;
     }
 
+    let namespace: string | undefined;
+    if (rawNamespace !== undefined) {
+      const nsResult = NamespaceSchema.safeParse(rawNamespace);
+      if (!nsResult.success) {
+        fail(res, 400, `Invalid namespace: ${nsResult.error.issues[0]?.message ?? 'validation failed'}`);
+        return;
+      }
+      namespace = nsResult.data;
+    }
+
     let agentId: string;
     try {
       agentId = getAgentId(req);
@@ -412,7 +437,7 @@ export function createApp(deps: AppDependencies): express.Express {
     }
 
     // Check cache
-    const key = timelineKey(agentId, from as string | undefined, to as string | undefined, limitNum);
+    const key = timelineKey(agentId, from as string | undefined, to as string | undefined, limitNum) + (namespace ? `:${namespace}` : '');
     const cached = await cacheGet(key);
     if (cached !== null) {
       res.setHeader('X-Cache', 'HIT');
@@ -423,7 +448,7 @@ export function createApp(deps: AppDependencies): express.Express {
     res.setHeader('X-Cache', 'MISS');
 
     try {
-      const entries = await manager.timeline(agentId, fromDate, toDate, limitNum);
+      const entries = await manager.timeline(agentId, fromDate, toDate, limitNum, namespace);
       void cacheSet(key, entries, 'search');
       ok(res, entries);
     } catch (err) {
@@ -555,15 +580,18 @@ export function createApp(deps: AppDependencies): express.Express {
    * Body: { mode?: "concat" | "summarize" }
    */
   app.post('/memory/:agentId/consolidate', requireScope('memforge:write'), async (req: Request, res: Response) => {
-    const { mode } = (req.body ?? {}) as { mode?: string };
-
-    if (mode && mode !== 'concat' && mode !== 'summarize') {
-      fail(res, 400, '"mode" must be one of: concat, summarize');
+    const parsed = ConsolidateSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      fail(res, 400, issue?.path[0] === 'namespace'
+        ? `Invalid namespace: ${issue.message}`
+        : '"mode" must be one of: concat, summarize');
       return;
     }
+    const { mode, namespace } = parsed.data;
 
     try {
-      const result = await manager.consolidate(getAgentId(req), mode as ConsolidationMode | undefined);
+      const result = await manager.consolidate(getAgentId(req), mode as ConsolidationMode | undefined, namespace ? { namespace } : undefined);
       void invalidateAgent(getAgentId(req));
       ok(res, result);
     } catch (err) {
@@ -580,6 +608,17 @@ export function createApp(deps: AppDependencies): express.Express {
    * GET /memory/:agentId/stats
    */
   app.get('/memory/:agentId/stats', requireScope('memforge:read'), async (req: Request, res: Response) => {
+    const rawNamespace = req.query['namespace'];
+    let namespace: string | undefined;
+    if (rawNamespace !== undefined) {
+      const nsResult = NamespaceSchema.safeParse(rawNamespace);
+      if (!nsResult.success) {
+        fail(res, 400, `Invalid namespace: ${nsResult.error.issues[0]?.message ?? 'validation failed'}`);
+        return;
+      }
+      namespace = nsResult.data;
+    }
+
     let agentId: string;
     try {
       agentId = getAgentId(req);
@@ -588,7 +627,7 @@ export function createApp(deps: AppDependencies): express.Express {
       return;
     }
 
-    const key = statsKey(agentId);
+    const key = statsKey(agentId) + (namespace ? `:${namespace}` : '');
     const cached = await cacheGet(key);
     if (cached !== null) {
       res.setHeader('X-Cache', 'HIT');
@@ -599,7 +638,7 @@ export function createApp(deps: AppDependencies): express.Express {
     res.setHeader('X-Cache', 'MISS');
 
     try {
-      const stats = await manager.stats(agentId);
+      const stats = await manager.stats(agentId, namespace);
       void cacheSet(key, stats, 'hot');
       ok(res, stats);
     } catch (err) {
@@ -638,14 +677,20 @@ export function createApp(deps: AppDependencies): express.Express {
    * Body: { tokenBudget?, evictionThreshold?, revisionThreshold?, includeReflection? }
    */
   app.post('/memory/:agentId/sleep', requireScope('memforge:write'), async (req: Request, res: Response) => {
-    const body = (req.body ?? {}) as Record<string, unknown>;
+    const parsed = SleepSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      fail(res, 400, issue?.message ?? 'Invalid request body');
+      return;
+    }
+    const { tokenBudget, evictionThreshold, revisionThreshold, includeReflection } = parsed.data;
 
     try {
       const result = await manager.sleep(getAgentId(req), {
-        tokenBudget: typeof body['tokenBudget'] === 'number' ? body['tokenBudget'] : undefined,
-        evictionThreshold: typeof body['evictionThreshold'] === 'number' ? body['evictionThreshold'] : undefined,
-        revisionThreshold: typeof body['revisionThreshold'] === 'number' ? body['revisionThreshold'] : undefined,
-        includeReflection: typeof body['includeReflection'] === 'boolean' ? body['includeReflection'] : undefined,
+        tokenBudget,
+        evictionThreshold,
+        revisionThreshold,
+        includeReflection,
       });
       void invalidateAgent(getAgentId(req));
       ok(res, result);
@@ -677,14 +722,25 @@ export function createApp(deps: AppDependencies): express.Express {
    */
   app.get('/memory/:agentId/resume', requireScope('memforge:read'), async (req: Request, res: Response) => {
     const limit = req.query['limit'];
+    const rawNamespace = req.query['namespace'];
     const limitNum = limit !== undefined ? parseInt(limit as string, 10) : 5;
     if (isNaN(limitNum) || limitNum < 1 || limitNum > 20) {
       fail(res, 400, '"limit" must be an integer between 1 and 20');
       return;
     }
 
+    let namespace: string | undefined;
+    if (rawNamespace !== undefined) {
+      const nsResult = NamespaceSchema.safeParse(rawNamespace);
+      if (!nsResult.success) {
+        fail(res, 400, `Invalid namespace: ${nsResult.error.issues[0]?.message ?? 'validation failed'}`);
+        return;
+      }
+      namespace = nsResult.data;
+    }
+
     try {
-      const context = await manager.resume(getAgentId(req), limitNum);
+      const context = await manager.resume(getAgentId(req), limitNum, namespace);
       ok(res, context);
     } catch (err) {
       fail(res, 500, (err as Error).message);
@@ -809,8 +865,19 @@ export function createApp(deps: AppDependencies): express.Express {
    * Export agent's full memory as JSONL.
    */
   app.get('/memory/:agentId/export', requireScope('memforge:read'), async (req: Request, res: Response) => {
+    const rawNamespace = req.query['namespace'];
+    let namespace: string | undefined;
+    if (rawNamespace !== undefined) {
+      const nsResult = NamespaceSchema.safeParse(rawNamespace);
+      if (!nsResult.success) {
+        fail(res, 400, `Invalid namespace: ${nsResult.error.issues[0]?.message ?? 'validation failed'}`);
+        return;
+      }
+      namespace = nsResult.data;
+    }
+
     try {
-      const lines = await manager.exportMemory(getAgentId(req));
+      const lines = await manager.exportMemory(getAgentId(req), namespace);
       res.setHeader('Content-Type', 'application/x-ndjson');
       res.setHeader('Content-Disposition', `attachment; filename="${getAgentId(req)}-memory.jsonl"`);
       res.send(lines.join('\n') + '\n');
@@ -825,19 +892,42 @@ export function createApp(deps: AppDependencies): express.Express {
    * Body: JSONL text (one JSON object per line)
    */
   app.post('/memory/:agentId/import', requireScope('memforge:write'), async (req: Request, res: Response) => {
-    const body = req.body as { lines?: string[] } | string;
+    const body = req.body as { lines?: string[]; namespace?: string } | string;
     let lines: string[];
+    let bodyNamespace: string | undefined;
+
     if (typeof body === 'string') {
       lines = body.split('\n').filter((l) => l.trim());
     } else if (Array.isArray(body.lines)) {
       lines = body.lines;
+      if (body.namespace !== undefined) {
+        const nsResult = NamespaceSchema.safeParse(body.namespace);
+        if (!nsResult.success) {
+          fail(res, 400, `Invalid namespace: ${nsResult.error.issues[0]?.message ?? 'validation failed'}`);
+          return;
+        }
+        bodyNamespace = nsResult.data;
+      }
     } else {
       fail(res, 400, 'Body must be { "lines": [...] } or raw JSONL text');
       return;
     }
 
+    // For each record that doesn't carry its own namespace, inject the body-level fallback.
+    const enrichedLines = bodyNamespace
+      ? lines.map((line) => {
+          try {
+            const obj = JSON.parse(line) as Record<string, unknown>;
+            if (!obj['namespace']) obj['namespace'] = bodyNamespace;
+            return JSON.stringify(obj);
+          } catch {
+            return line;
+          }
+        })
+      : lines;
+
     try {
-      const result = await manager.importMemory(getAgentId(req), lines);
+      const result = await manager.importMemory(getAgentId(req), enrichedLines);
       void invalidateAgent(getAgentId(req));
       ok(res, result);
     } catch (err) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -61,8 +61,8 @@ export class MemForgeClient {
   // ─── Memory Operations ──────────────────────────────────────────────────
 
   /** Add a memory event to the hot tier. */
-  async add(agentId: string, content: string, metadata?: Record<string, unknown>): Promise<AddResult> {
-    return this.post<AddResult>(`/memory/${enc(agentId)}/add`, { content, metadata });
+  async add(agentId: string, content: string, metadata?: Record<string, unknown>, namespace?: string): Promise<AddResult> {
+    return this.post<AddResult>(`/memory/${enc(agentId)}/add`, { content, metadata, ...(namespace ? { namespace } : {}) });
   }
 
   /** Search warm tier memory. */
@@ -73,6 +73,7 @@ export class MemForgeClient {
     after?: string;
     before?: string;
     decay?: number;
+    namespace?: string;
   }): Promise<QueryResult[]> {
     const params = new URLSearchParams({ q: options.q });
     if (options.limit !== undefined) params.set('limit', String(options.limit));
@@ -80,6 +81,7 @@ export class MemForgeClient {
     if (options.after) params.set('after', options.after);
     if (options.before) params.set('before', options.before);
     if (options.decay !== undefined) params.set('decay', String(options.decay));
+    if (options.namespace) params.set('namespace', options.namespace);
     return this.get<QueryResult[]>(`/memory/${enc(agentId)}/query?${params}`);
   }
 
@@ -88,18 +90,23 @@ export class MemForgeClient {
     from?: string;
     to?: string;
     limit?: number;
+    namespace?: string;
   }): Promise<TimelineEntry[]> {
     const params = new URLSearchParams();
     if (options?.from) params.set('from', options.from);
     if (options?.to) params.set('to', options.to);
     if (options?.limit !== undefined) params.set('limit', String(options.limit));
+    if (options?.namespace) params.set('namespace', options.namespace);
     const qs = params.toString();
     return this.get<TimelineEntry[]>(`/memory/${enc(agentId)}/timeline${qs ? '?' + qs : ''}`);
   }
 
   /** Trigger hot→warm consolidation. */
-  async consolidate(agentId: string, mode?: ConsolidationMode): Promise<ConsolidateResult> {
-    return this.post<ConsolidateResult>(`/memory/${enc(agentId)}/consolidate`, mode ? { mode } : {});
+  async consolidate(agentId: string, mode?: ConsolidationMode, namespace?: string): Promise<ConsolidateResult> {
+    const body: Record<string, unknown> = {};
+    if (mode) body['mode'] = mode;
+    if (namespace) body['namespace'] = namespace;
+    return this.post<ConsolidateResult>(`/memory/${enc(agentId)}/consolidate`, body);
   }
 
   /** Archive and clear all memory for an agent. */
@@ -108,8 +115,9 @@ export class MemForgeClient {
   }
 
   /** Get memory tier statistics. */
-  async stats(agentId: string): Promise<AgentStats> {
-    return this.get<AgentStats>(`/memory/${enc(agentId)}/stats`);
+  async stats(agentId: string, namespace?: string): Promise<AgentStats> {
+    const qs = namespace ? `?namespace=${enc(namespace)}` : '';
+    return this.get<AgentStats>(`/memory/${enc(agentId)}/stats${qs}`);
   }
 
   // ─── Knowledge Graph ────────────────────────────────────────────────────
@@ -164,7 +172,8 @@ export class MemForgeClient {
 
   // ─── Sleep Cycle ───────────────────────────────────────────────────────────
 
-  /** Trigger a sleep cycle — scores, triages, revises, and maintains memory. */
+  /** Trigger a sleep cycle — scores, triages, revises, and maintains memory.
+   * Agent-wide: the cycle processes all namespaces for the agent. */
   async sleep(agentId: string, options?: {
     tokenBudget?: number;
     evictionThreshold?: number;
@@ -180,9 +189,10 @@ export class MemForgeClient {
   }
 
   /** Generate a session resumption context for an agent. */
-  async resume(agentId: string, limit?: number): Promise<ResumeContext> {
+  async resume(agentId: string, limit?: number, namespace?: string): Promise<ResumeContext> {
     const params = new URLSearchParams();
     if (limit !== undefined) params.set('limit', String(limit));
+    if (namespace) params.set('namespace', namespace);
     const qs = params.toString();
     return this.get<ResumeContext>(`/memory/${enc(agentId)}/resume${qs ? `?${qs}` : ''}`);
   }
@@ -298,28 +308,28 @@ export class ResilientMemForgeClient {
   }
 
   // Memory operations — return empty results on failure
-  async add(agentId: string, content: string, metadata?: Record<string, unknown>): Promise<AddResult | null> {
-    return this.safe('add', () => this.client.add(agentId, content, metadata), null);
+  async add(agentId: string, content: string, metadata?: Record<string, unknown>, namespace?: string): Promise<AddResult | null> {
+    return this.safe('add', () => this.client.add(agentId, content, metadata, namespace), null);
   }
 
-  async query(agentId: string, options: { q: string; limit?: number; mode?: QueryMode; after?: string; before?: string; decay?: number }): Promise<QueryResult[]> {
+  async query(agentId: string, options: { q: string; limit?: number; mode?: QueryMode; after?: string; before?: string; decay?: number; namespace?: string }): Promise<QueryResult[]> {
     return this.safe('query', () => this.client.query(agentId, options), []);
   }
 
-  async timeline(agentId: string, options?: { from?: string; to?: string; limit?: number }): Promise<TimelineEntry[]> {
+  async timeline(agentId: string, options?: { from?: string; to?: string; limit?: number; namespace?: string }): Promise<TimelineEntry[]> {
     return this.safe('timeline', () => this.client.timeline(agentId, options), []);
   }
 
-  async consolidate(agentId: string, mode?: ConsolidationMode): Promise<ConsolidateResult | null> {
-    return this.safe('consolidate', () => this.client.consolidate(agentId, mode), null);
+  async consolidate(agentId: string, mode?: ConsolidationMode, namespace?: string): Promise<ConsolidateResult | null> {
+    return this.safe('consolidate', () => this.client.consolidate(agentId, mode, namespace), null);
   }
 
   async clear(agentId: string): Promise<ClearResult | null> {
     return this.safe('clear', () => this.client.clear(agentId), null);
   }
 
-  async stats(agentId: string): Promise<AgentStats | null> {
-    return this.safe('stats', () => this.client.stats(agentId), null);
+  async stats(agentId: string, namespace?: string): Promise<AgentStats | null> {
+    return this.safe('stats', () => this.client.stats(agentId, namespace), null);
   }
 
   async searchEntities(agentId: string, options?: { q?: string; type?: string; limit?: number }): Promise<EntitySearchResult[]> {
@@ -350,8 +360,8 @@ export class ResilientMemForgeClient {
     return this.safe('memoryHealth', () => this.client.memoryHealth(agentId), null);
   }
 
-  async resume(agentId: string, limit?: number): Promise<ResumeContext | null> {
-    return this.safe('resume', () => this.client.resume(agentId, limit), null);
+  async resume(agentId: string, limit?: number, namespace?: string): Promise<ResumeContext | null> {
+    return this.safe('resume', () => this.client.resume(agentId, limit, namespace), null);
   }
 
   async feedback(agentId: string, retrievalIds: Array<number | bigint>, outcome: FeedbackOutcome, metadata?: Record<string, unknown>): Promise<FeedbackResult | null> {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -54,6 +54,7 @@ const TOOLS: MCPToolDefinition[] = [
         agent_id: { type: 'string', description: 'Agent/session identifier' },
         content: { type: 'string', description: 'Memory content to store' },
         metadata: { type: 'object', description: 'Optional structured metadata' },
+        namespace: { type: 'string', description: 'Memory namespace (default: "default")' },
       },
       required: ['agent_id', 'content'],
     },
@@ -68,6 +69,7 @@ const TOOLS: MCPToolDefinition[] = [
         q: { type: 'string', description: 'Natural language search query' },
         limit: { type: 'integer', description: 'Max results (default 10)' },
         mode: { type: 'string', enum: ['keyword', 'semantic', 'hybrid'], description: 'Search mode' },
+        namespace: { type: 'string', description: 'Memory namespace (default: "default")' },
       },
       required: ['agent_id', 'q'],
     },
@@ -82,6 +84,7 @@ const TOOLS: MCPToolDefinition[] = [
         from: { type: 'string', description: 'Start of time range (ISO 8601)' },
         to: { type: 'string', description: 'End of time range (ISO 8601)' },
         limit: { type: 'integer', description: 'Max results (default 50)' },
+        namespace: { type: 'string', description: 'Memory namespace (default: "default")' },
       },
       required: ['agent_id'],
     },
@@ -145,6 +148,7 @@ const TOOLS: MCPToolDefinition[] = [
       properties: {
         agent_id: { type: 'string', description: 'Agent/session identifier' },
         mode: { type: 'string', enum: ['concat', 'summarize'], description: 'Consolidation mode' },
+        namespace: { type: 'string', description: 'Memory namespace (default: "default")' },
       },
       required: ['agent_id'],
     },
@@ -164,7 +168,7 @@ const TOOLS: MCPToolDefinition[] = [
   },
   {
     name: 'memforge_sleep',
-    description: 'Trigger a sleep cycle — scores importance, evicts low-value memories, revises low-confidence memories via LLM, maintains graph.',
+    description: 'Trigger a sleep cycle — scores importance, evicts low-value memories, revises low-confidence memories via LLM, maintains graph. Agent-wide: processes all namespaces for the agent.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -192,6 +196,7 @@ const TOOLS: MCPToolDefinition[] = [
       type: 'object',
       properties: {
         agent_id: { type: 'string', description: 'Agent/session identifier' },
+        namespace: { type: 'string', description: 'Memory namespace (default: overall stats)' },
       },
       required: ['agent_id'],
     },
@@ -299,13 +304,14 @@ async function executeTool(client: MemForgeClient, name: string, args: Record<st
 
   switch (name) {
     case 'memforge_add':
-      return client.add(agentId, args['content'] as string, args['metadata'] as Record<string, unknown> | undefined);
+      return client.add(agentId, args['content'] as string, args['metadata'] as Record<string, unknown> | undefined, args['namespace'] as string | undefined);
 
     case 'memforge_query':
       return client.query(agentId, {
         q: args['q'] as string,
         limit: args['limit'] as number | undefined,
         mode: args['mode'] as 'keyword' | 'semantic' | 'hybrid' | undefined,
+        namespace: args['namespace'] as string | undefined,
       });
 
     case 'memforge_timeline':
@@ -313,6 +319,7 @@ async function executeTool(client: MemForgeClient, name: string, args: Record<st
         from: args['from'] as string | undefined,
         to: args['to'] as string | undefined,
         limit: args['limit'] as number | undefined,
+        namespace: args['namespace'] as string | undefined,
       });
 
     case 'memforge_entities':
@@ -332,7 +339,7 @@ async function executeTool(client: MemForgeClient, name: string, args: Record<st
       return client.getReflections(agentId, args['limit'] as number | undefined);
 
     case 'memforge_consolidate':
-      return client.consolidate(agentId, args['mode'] as 'concat' | 'summarize' | undefined);
+      return client.consolidate(agentId, args['mode'] as 'concat' | 'summarize' | undefined, args['namespace'] as string | undefined);
 
     case 'memforge_procedures':
       return client.getProcedures(agentId, {
@@ -349,7 +356,7 @@ async function executeTool(client: MemForgeClient, name: string, args: Record<st
       return client.memoryHealth(agentId);
 
     case 'memforge_stats':
-      return client.stats(agentId);
+      return client.stats(agentId, args['namespace'] as string | undefined);
 
     case 'memforge_feedback':
       return client.feedback(agentId, args['retrieval_ids'] as number[], args['outcome'] as 'positive' | 'negative' | 'neutral');

--- a/src/memory-manager.ts
+++ b/src/memory-manager.ts
@@ -847,10 +847,12 @@ Ranking (numbers only):`;
     from?: Date,
     to?: Date,
     limit = 50,
+    namespace?: string,
   ): Promise<TimelineEntry[]> {
     this.assertAgentId(agentId);
+    const ns = resolveNamespace(namespace);
 
-    const params: SqlParam[] =[agentId];
+    const params: SqlParam[] = [agentId, ns];
     const clauses: string[] = [];
 
     if (from) {
@@ -868,7 +870,7 @@ Ranking (numbers only):`;
     const { rows } = await this.pool.query<TimelineEntry>(
       `SELECT id, content, metadata, time_start, time_end, consolidated_at, access_count
        FROM warm_tier
-       WHERE agent_id = $1
+       WHERE agent_id = $1 AND namespace = $2
          ${clauses.join(' ')}
        ORDER BY COALESCE(time_start, consolidated_at) ASC
        LIMIT $${limitIdx}`,
@@ -1359,9 +1361,14 @@ Ranking (numbers only):`;
 
   // ─── stats ────────────────────────────────────────────────────────────────
 
-  async stats(agentId: string): Promise<AgentStats> {
+  async stats(agentId: string, namespace?: string): Promise<AgentStats> {
     this.assertAgentId(agentId);
+    const ns = resolveNamespace(namespace);
 
+    // Namespaced subqueries filter by (agent_id, namespace). Entities and
+    // relationships are agent-scoped (not namespaced) by design — see
+    // migration-v3.1 header for why — so those counts are the full agent totals
+    // regardless of namespace filter.
     const { rows: statsRows } = await this.pool.query<{
       last_seen: Date;
       hot_count: string;
@@ -1374,18 +1381,18 @@ Ranking (numbers only):`;
     }>(
       `SELECT
          a.last_seen,
-         (SELECT count(*) FROM hot_tier WHERE agent_id = $1) AS hot_count,
-         (SELECT count(*) FROM warm_tier WHERE agent_id = $1) AS warm_count,
-         (SELECT count(*) FROM cold_tier WHERE agent_id = $1) AS cold_count,
+         (SELECT count(*) FROM hot_tier WHERE agent_id = $1 AND namespace = $2) AS hot_count,
+         (SELECT count(*) FROM warm_tier WHERE agent_id = $1 AND namespace = $2) AS warm_count,
+         (SELECT count(*) FROM cold_tier WHERE agent_id = $1 AND namespace = $2) AS cold_count,
          (SELECT count(*) FROM entities WHERE agent_id = $1) AS entity_count,
          (SELECT count(*) FROM relationships WHERE agent_id = $1) AS relationship_count,
-         (SELECT count(*) FROM reflections WHERE agent_id = $1) AS reflection_count,
+         (SELECT count(*) FROM reflections WHERE agent_id = $1 AND namespace = $2) AS reflection_count,
          (SELECT completed_at FROM consolidation_log
-          WHERE agent_id = $1 AND status = 'complete'
+          WHERE agent_id = $1 AND namespace = $2 AND status = 'complete'
           ORDER BY completed_at DESC LIMIT 1) AS last_consolidation
        FROM agents a
        WHERE a.id = $1`,
-      [agentId],
+      [agentId, ns],
     );
 
     if (statsRows.length === 0) {
@@ -2047,11 +2054,12 @@ Ranking (numbers only):`;
    * Generate a resumption context for an agent starting a new session.
    * Returns recent important memories, active procedures, and open contradictions.
    */
-  async resume(agentId: string, limit = 5): Promise<ResumeContext> {
+  async resume(agentId: string, limit = 5, namespace?: string): Promise<ResumeContext> {
     this.assertAgentId(agentId);
     if (limit < 1 || limit > 20) {
       throw new TypeError('limit must be between 1 and 20');
     }
+    const ns = resolveNamespace(namespace);
 
     // Get agent last_seen
     const agentRow = await this.pool.query<{ last_seen: Date }>(
@@ -2061,28 +2069,28 @@ Ranking (numbers only):`;
     const lastSeen = agentRow.rows[0]?.last_seen ?? null;
     const timeSinceMs = lastSeen ? Date.now() - lastSeen.getTime() : null;
 
-    // Top memories by importance
+    // Top memories by importance (scoped to namespace)
     const memories = await this.pool.query<{ id: bigint; content: string; importance: number; consolidated_at: Date }>(
       `SELECT id, content, importance, consolidated_at
-       FROM warm_tier WHERE agent_id = $1
-       ORDER BY importance DESC LIMIT $2`,
-      [agentId, limit],
+       FROM warm_tier WHERE agent_id = $1 AND namespace = $2
+       ORDER BY importance DESC LIMIT $3`,
+      [agentId, ns, limit],
     );
 
-    // Active procedures
+    // Active procedures (scoped to namespace)
     const procs = await this.pool.query<{ condition: string; action: string; confidence: number }>(
       `SELECT condition, action, confidence
-       FROM procedures WHERE agent_id = $1 AND active = true
+       FROM procedures WHERE agent_id = $1 AND namespace = $2 AND active = true
        ORDER BY confidence DESC LIMIT 10`,
-      [agentId],
+      [agentId, ns],
     );
 
-    // Open contradictions from recent reflections
+    // Open contradictions from recent reflections (scoped to namespace)
     const reflections = await this.pool.query<{ contradictions: string[] }>(
       `SELECT contradictions FROM reflections
-       WHERE agent_id = $1 AND array_length(contradictions, 1) > 0
+       WHERE agent_id = $1 AND namespace = $2 AND array_length(contradictions, 1) > 0
        ORDER BY created_at DESC LIMIT 3`,
-      [agentId],
+      [agentId, ns],
     );
     const contradictions: string[] = [];
     for (const r of reflections.rows) {
@@ -2091,11 +2099,11 @@ Ranking (numbers only):`;
       }
     }
 
-    // Memory health summary
+    // Memory health summary (scoped to namespace)
     const healthRow = await this.pool.query<{ total: string; avg_imp: number; avg_conf: number }>(
       `SELECT COUNT(*)::text as total, COALESCE(AVG(importance), 0) as avg_imp, COALESCE(AVG(confidence), 0) as avg_conf
-       FROM warm_tier WHERE agent_id = $1`,
-      [agentId],
+       FROM warm_tier WHERE agent_id = $1 AND namespace = $2`,
+      [agentId, ns],
     );
     const h = healthRow.rows[0];
 
@@ -2709,21 +2717,23 @@ Guidelines:
    * Export an agent's full memory as JSONL lines.
    * Includes warm-tier memories, entities, relationships, procedures, and reflections.
    */
-  async exportMemory(agentId: string): Promise<string[]> {
+  async exportMemory(agentId: string, namespace?: string): Promise<string[]> {
     this.assertAgentId(agentId);
+    const ns = resolveNamespace(namespace);
 
     const lines: string[] = [];
 
-    // Warm-tier memories
+    // Warm-tier memories (scoped to namespace)
     const memories = await this.pool.query<{ content: string; summary: string | null; metadata: Record<string, unknown>; importance: number; confidence: number; consolidated_at: Date }>(
-      `SELECT content, summary, metadata, importance, confidence, consolidated_at FROM warm_tier WHERE agent_id = $1 ORDER BY importance DESC`,
-      [agentId],
+      `SELECT content, summary, metadata, importance, confidence, consolidated_at FROM warm_tier WHERE agent_id = $1 AND namespace = $2 ORDER BY importance DESC`,
+      [agentId, ns],
     );
     for (const m of memories.rows) {
       lines.push(JSON.stringify({ type: 'memory', content: m.content, summary: m.summary, metadata: m.metadata, importance: m.importance, confidence: m.confidence, consolidated_at: m.consolidated_at }));
     }
 
-    // Entities
+    // Entities — agent-scoped (not namespaced); included in every export so
+    // knowledge graph is portable even when re-importing into a single namespace.
     const entities = await this.pool.query<{ name: string; entity_type: string; mention_count: number }>(
       `SELECT name, entity_type, mention_count FROM entities WHERE agent_id = $1`,
       [agentId],
@@ -2732,7 +2742,7 @@ Guidelines:
       lines.push(JSON.stringify({ type: 'entity', name: e.name, entity_type: e.entity_type, mention_count: e.mention_count }));
     }
 
-    // Relationships
+    // Relationships — agent-scoped (not namespaced), same reasoning as entities.
     const rels = await this.pool.query<{ source: string; target: string; relation_type: string; weight: number }>(
       `SELECT s.name as source, t.name as target, r.relation_type, r.weight
        FROM relationships r
@@ -2745,19 +2755,19 @@ Guidelines:
       lines.push(JSON.stringify({ type: 'relationship', source: r.source, target: r.target, relation_type: r.relation_type, weight: r.weight }));
     }
 
-    // Procedures
+    // Procedures (scoped to namespace)
     const procs = await this.pool.query<{ condition: string; action: string; confidence: number; active: boolean }>(
-      `SELECT condition, action, confidence, active FROM procedures WHERE agent_id = $1`,
-      [agentId],
+      `SELECT condition, action, confidence, active FROM procedures WHERE agent_id = $1 AND namespace = $2`,
+      [agentId, ns],
     );
     for (const p of procs.rows) {
       lines.push(JSON.stringify({ type: 'procedure', condition: p.condition, action: p.action, confidence: p.confidence, active: p.active }));
     }
 
-    // Reflections
+    // Reflections (scoped to namespace)
     const reflections = await this.pool.query<{ content: string; key_insights: string[]; reflection_level: number }>(
-      `SELECT content, key_insights, reflection_level FROM reflections WHERE agent_id = $1 ORDER BY created_at DESC LIMIT 20`,
-      [agentId],
+      `SELECT content, key_insights, reflection_level FROM reflections WHERE agent_id = $1 AND namespace = $2 ORDER BY created_at DESC LIMIT 20`,
+      [agentId, ns],
     );
     for (const r of reflections.rows) {
       lines.push(JSON.stringify({ type: 'reflection', content: r.content, key_insights: r.key_insights, reflection_level: r.reflection_level }));

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -73,6 +73,7 @@ export function buildOpenApiSpec(port: number): Record<string, unknown> {
                   properties: {
                     content: { type: 'string', description: 'Memory content to store' },
                     metadata: { type: 'object', additionalProperties: true },
+                    namespace: { type: 'string', pattern: '^[a-z0-9][a-z0-9_-]*$', description: 'Memory namespace (default: "default")' },
                   },
                 },
               },
@@ -97,6 +98,7 @@ export function buildOpenApiSpec(port: number): Record<string, unknown> {
             { name: 'after', in: 'query', schema: { type: 'string', format: 'date-time' }, description: 'Only return memories after this timestamp' },
             { name: 'before', in: 'query', schema: { type: 'string', format: 'date-time' }, description: 'Only return memories before this timestamp' },
             { name: 'decay', in: 'query', schema: { type: 'number', minimum: 0 }, description: 'Temporal decay rate per hour (0 = no decay)' },
+            { name: 'namespace', in: 'query', schema: { type: 'string', pattern: '^[a-z0-9][a-z0-9_-]*$' }, description: 'Memory namespace (default: "default")' },
           ],
           responses: {
             '200': { description: 'Search results with rank scores', content: { 'application/json': { schema: { '$ref': '#/components/schemas/OkResponse' } } } },
@@ -114,6 +116,7 @@ export function buildOpenApiSpec(port: number): Record<string, unknown> {
             { name: 'from', in: 'query', schema: { type: 'string', format: 'date-time' }, description: 'Start of time range' },
             { name: 'to', in: 'query', schema: { type: 'string', format: 'date-time' }, description: 'End of time range' },
             { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 500, default: 50 } },
+            { name: 'namespace', in: 'query', schema: { type: 'string', pattern: '^[a-z0-9][a-z0-9_-]*$' }, description: 'Memory namespace (default: "default")' },
           ],
           responses: {
             '200': { description: 'Chronologically ordered memories', content: { 'application/json': { schema: { '$ref': '#/components/schemas/OkResponse' } } } },
@@ -210,6 +213,7 @@ export function buildOpenApiSpec(port: number): Record<string, unknown> {
                   type: 'object',
                   properties: {
                     mode: { type: 'string', enum: ['concat', 'summarize'], description: 'Consolidation mode (default: from server config)' },
+                    namespace: { type: 'string', pattern: '^[a-z0-9][a-z0-9_-]*$', description: 'Memory namespace (default: "default")' },
                   },
                 },
               },
@@ -228,6 +232,7 @@ export function buildOpenApiSpec(port: number): Record<string, unknown> {
           tags: ['Memory'],
           parameters: [
             { name: 'agentId', in: 'path', required: true, schema: { type: 'string' } },
+            { name: 'namespace', in: 'query', schema: { type: 'string', pattern: '^[a-z0-9][a-z0-9_-]*$' }, description: 'Scope stats to this namespace; omit for overall stats' },
           ],
           responses: {
             '200': { description: 'Memory stats', content: { 'application/json': { schema: { '$ref': '#/components/schemas/OkResponse' } } } },
@@ -341,6 +346,92 @@ export function buildOpenApiSpec(port: number): Record<string, unknown> {
           },
           responses: {
             '200': { description: 'Relevant memories and procedures', content: { 'application/json': { schema: { '$ref': '#/components/schemas/OkResponse' } } } },
+            '400': { '$ref': '#/components/responses/BadRequest' },
+            '500': { '$ref': '#/components/responses/InternalError' },
+          },
+        },
+      },
+      '/memory/{agentId}/sleep': {
+        post: {
+          summary: 'Trigger a sleep cycle — scores, evicts, revises memory',
+          tags: ['Memory'],
+          parameters: [
+            { name: 'agentId', in: 'path', required: true, schema: { type: 'string' } },
+          ],
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    tokenBudget: { type: 'integer', description: 'Max LLM tokens (default 100000)' },
+                    evictionThreshold: { type: 'number' },
+                    revisionThreshold: { type: 'number' },
+                    includeReflection: { type: 'boolean' },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            '200': { description: 'Sleep cycle result', content: { 'application/json': { schema: { '$ref': '#/components/schemas/OkResponse' } } } },
+            '400': { '$ref': '#/components/responses/BadRequest' },
+            '500': { '$ref': '#/components/responses/InternalError' },
+          },
+        },
+      },
+      '/memory/{agentId}/resume': {
+        get: {
+          summary: 'Generate session resumption context',
+          tags: ['Memory'],
+          parameters: [
+            { name: 'agentId', in: 'path', required: true, schema: { type: 'string' } },
+            { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 20, default: 5 } },
+            { name: 'namespace', in: 'query', schema: { type: 'string', pattern: '^[a-z0-9][a-z0-9_-]*$' }, description: 'Memory namespace (default: "default")' },
+          ],
+          responses: {
+            '200': { description: 'Resumption context', content: { 'application/json': { schema: { '$ref': '#/components/schemas/OkResponse' } } } },
+            '500': { '$ref': '#/components/responses/InternalError' },
+          },
+        },
+      },
+      '/memory/{agentId}/export': {
+        get: {
+          summary: 'Export agent memory as JSONL',
+          tags: ['Memory'],
+          parameters: [
+            { name: 'agentId', in: 'path', required: true, schema: { type: 'string' } },
+            { name: 'namespace', in: 'query', schema: { type: 'string', pattern: '^[a-z0-9][a-z0-9_-]*$' }, description: 'Scope export to this namespace (default: all namespaces)' },
+          ],
+          responses: {
+            '200': { description: 'JSONL export', content: { 'application/x-ndjson': { schema: { type: 'string' } } } },
+            '500': { '$ref': '#/components/responses/InternalError' },
+          },
+        },
+      },
+      '/memory/{agentId}/import': {
+        post: {
+          summary: 'Import JSONL into agent memory',
+          tags: ['Memory'],
+          parameters: [
+            { name: 'agentId', in: 'path', required: true, schema: { type: 'string' } },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    lines: { type: 'array', items: { type: 'string' }, description: 'JSONL lines to import' },
+                    namespace: { type: 'string', pattern: '^[a-z0-9][a-z0-9_-]*$', description: 'Fallback namespace for records without one (default: "default")' },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            '200': { description: 'Import result', content: { 'application/json': { schema: { '$ref': '#/components/schemas/OkResponse' } } } },
             '400': { '$ref': '#/components/responses/BadRequest' },
             '500': { '$ref': '#/components/responses/InternalError' },
           },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -29,6 +29,38 @@ export const NamespacedRequestSchema = z.object({
   namespace: NamespaceSchema.optional(),
 });
 
+// Per-route request schemas — each extends the base namespace holder.
+
+export const AddMemorySchema = z.object({
+  content: z.string(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  outcome_type: z.string().optional(),
+  hints: z.record(z.string(), z.unknown()).optional(),
+  namespace: NamespaceSchema.optional(),
+});
+
+export const ConsolidateSchema = z.object({
+  mode: z.enum(['concat', 'summarize']).optional(),
+  namespace: NamespaceSchema.optional(),
+});
+
+// Sleep is agent-wide — it runs the 10-phase cycle across all namespaces for
+// the agent. Namespace-scoped sleep would require extending every sleep phase
+// to filter by namespace; tracked as a future enhancement. The schema
+// intentionally does NOT accept a namespace field so the API doesn't claim
+// behavior it cannot deliver.
+export const SleepSchema = z.object({
+  tokenBudget: z.number().optional(),
+  evictionThreshold: z.number().optional(),
+  revisionThreshold: z.number().optional(),
+  includeReflection: z.boolean().optional(),
+});
+
+export const ImportSchema = z.object({
+  lines: z.array(z.string()).optional(),
+  namespace: NamespaceSchema.optional(),
+});
+
 // ─── LLM Response Schemas ───────────────────────────────────────────────────
 
 export const ConsolidationSummarySchema = z.object({

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -29,6 +29,7 @@ export const tools: ToolDefinition[] = [
         agent_id: { type: 'string', description: 'The agent/session identifier' },
         content: { type: 'string', description: 'The memory content to store' },
         metadata: { type: 'object', description: 'Optional structured metadata', additionalProperties: true },
+        namespace: { type: 'string', description: 'Memory namespace; defaults to "default"' },
       },
       required: ['agent_id', 'content'],
     },
@@ -45,6 +46,7 @@ export const tools: ToolDefinition[] = [
         mode: { type: 'string', enum: ['keyword', 'semantic', 'hybrid'], description: 'Search mode (default: hybrid if embeddings available)' },
         after: { type: 'string', format: 'date-time', description: 'Only return memories after this timestamp' },
         before: { type: 'string', format: 'date-time', description: 'Only return memories before this timestamp' },
+        namespace: { type: 'string', description: 'Memory namespace; defaults to "default"' },
       },
       required: ['agent_id', 'q'],
     },
@@ -59,6 +61,7 @@ export const tools: ToolDefinition[] = [
         from: { type: 'string', format: 'date-time', description: 'Start of time range' },
         to: { type: 'string', format: 'date-time', description: 'End of time range' },
         limit: { type: 'integer', description: 'Max results (default 50)', minimum: 1, maximum: 500 },
+        namespace: { type: 'string', description: 'Memory namespace; defaults to "default"' },
       },
       required: ['agent_id'],
     },
@@ -122,6 +125,7 @@ export const tools: ToolDefinition[] = [
       properties: {
         agent_id: { type: 'string', description: 'The agent/session identifier' },
         mode: { type: 'string', enum: ['concat', 'summarize'], description: 'Consolidation mode (default: from server config)' },
+        namespace: { type: 'string', description: 'Memory namespace; defaults to "default"' },
       },
       required: ['agent_id'],
     },
@@ -141,7 +145,7 @@ export const tools: ToolDefinition[] = [
   },
   {
     name: 'memforge_sleep',
-    description: 'Trigger a sleep cycle — background processing that scores memory importance, evicts low-value memories, revises low-confidence memories via LLM, and maintains the knowledge graph. Call during idle periods.',
+    description: 'Trigger a sleep cycle — background processing that scores memory importance, evicts low-value memories, revises low-confidence memories via LLM, and maintains the knowledge graph. Call during idle periods. Agent-wide: processes all namespaces.',
     input_schema: {
       type: 'object',
       properties: {
@@ -169,6 +173,7 @@ export const tools: ToolDefinition[] = [
       type: 'object',
       properties: {
         agent_id: { type: 'string', description: 'The agent/session identifier' },
+        namespace: { type: 'string', description: 'Scope stats to this namespace; omit for overall stats' },
       },
       required: ['agent_id'],
     },

--- a/tests/http-api.test.ts
+++ b/tests/http-api.test.ts
@@ -383,3 +383,70 @@ describe('Audit endpoints without audit chain', () => {
     assert.ok(body.error.includes('not configured') || body.error.includes('Audit'));
   });
 });
+
+// ─── Namespace support ───────────────────────────────────────────────────────
+
+describe('Namespace support', () => {
+  const NS_AGENT = 'test-agent-ns';
+
+  async function cleanupNsAgent(): Promise<void> {
+    await pool.query(`DELETE FROM warm_tier WHERE agent_id = $1`, [NS_AGENT]);
+    await pool.query(`DELETE FROM hot_tier WHERE agent_id = $1`, [NS_AGENT]);
+    await pool.query(`DELETE FROM agents WHERE id = $1`, [NS_AGENT]);
+  }
+
+  before(cleanupNsAgent);
+  after(cleanupNsAgent);
+
+  it('POST /memory/:agentId/add accepts namespace:"alpha" and consolidate scopes to it', async () => {
+    const addRes = await post(`/memory/${NS_AGENT}/add`, { content: 'alpha namespace memory', namespace: 'alpha' });
+    assert.equal(addRes.status, 200);
+    const addBody = await addRes.json() as { ok: boolean; data: { id: string } };
+    assert.equal(addBody.ok, true);
+    assert.ok(addBody.data.id, 'returns memory id');
+
+    // consolidate scoped to alpha
+    const conRes = await post(`/memory/${NS_AGENT}/consolidate`, { namespace: 'alpha' });
+    assert.equal(conRes.status, 200);
+    const conBody = await conRes.json() as { ok: boolean; data: { warm_rows_created: number } };
+    assert.equal(conBody.ok, true);
+    assert.ok(conBody.data.warm_rows_created >= 1, 'warm row created for alpha namespace');
+  });
+
+  it('GET /memory/:agentId/query?namespace=alpha returns only alpha rows', async () => {
+    const res = await get(`/memory/${NS_AGENT}/query?q=alpha+namespace&namespace=alpha`);
+    assert.equal(res.status, 200);
+    const body = await res.json() as { ok: boolean; data: unknown[] };
+    assert.equal(body.ok, true);
+    assert.ok(Array.isArray(body.data));
+  });
+
+  it('GET /memory/:agentId/query with no namespace does not see alpha rows in default namespace', async () => {
+    // Add a default-namespace memory first so the agent has rows
+    await post(`/memory/${NS_AGENT}/add`, { content: 'default namespace memory' });
+    await post(`/memory/${NS_AGENT}/consolidate`, {});
+
+    const res = await get(`/memory/${NS_AGENT}/query?q=alpha+namespace`);
+    assert.equal(res.status, 200);
+    const body = await res.json() as { ok: boolean; data: { content?: string; summary?: string }[] };
+    assert.equal(body.ok, true);
+    const texts = body.data.map((r) => (r.summary ?? r.content ?? '').toLowerCase());
+    assert.ok(!texts.some((t) => t.includes('alpha namespace memory')), 'default query does not cross into alpha namespace');
+  });
+
+  it('invalid namespace returns 400', async () => {
+    const res = await post(`/memory/${NS_AGENT}/add`, { content: 'test', namespace: 'Foo Bar' });
+    assert.equal(res.status, 400);
+    const body = await res.json() as { ok: boolean; error: string };
+    assert.equal(body.ok, false);
+    assert.ok(body.error.toLowerCase().includes('namespace'), 'error mentions namespace');
+  });
+
+  it('invalid namespace on GET /query returns 400', async () => {
+    const res = await get(`/memory/${NS_AGENT}/query?q=test&namespace=Foo+Bar`);
+    assert.equal(res.status, 400);
+    const body = await res.json() as { ok: boolean; error: string };
+    assert.equal(body.ok, false);
+    assert.ok(body.error.toLowerCase().includes('namespace'));
+  });
+});


### PR DESCRIPTION
## Summary

Exposes the memory \`namespace\` argument through every public surface. Backend support shipped in Sprint C.1 (PR #100); this PR makes it reachable from HTTP, MCP tools, TS SDK, Python SDK, and OpenAPI. Completes **#16 Memory Namespaces**.

Sleep is intentionally **agent-wide** (not namespace-scoped). Making it namespace-aware would require every phase in the 10-phase cycle to filter by namespace — deeper than this PR. \`SleepSchema\` explicitly does not accept \`namespace\` so the API doesn't claim behavior it can't deliver.

## Surfaces updated

| Surface | Routes / methods |
|---|---|
| HTTP (\`src/app.ts\`) | add, query, consolidate, import, export, timeline, resume, stats — all accept \`namespace\`. Cache keys for timeline/stats/resume now namespace-suffixed. |
| MemoryManager (\`src/memory-manager.ts\`) | timeline, stats, resume, exportMemory gained \`namespace?\` param beyond C.1's coverage. Entities/relationships stay agent-scoped (knowledge graph shared across namespaces by design, per migration-v3.1 header). |
| MCP (\`src/mcp.ts\`, \`src/tool-definitions.ts\`) | \`memforge_add/query/timeline/consolidate/stats\` accept \`namespace\`. \`memforge_sleep\` documented as agent-wide. |
| TS SDK (\`src/client.ts\`) | \`MemForgeClient\` + \`ResilientMemForgeClient\` — non-breaking positional signatures. |
| OpenAPI (\`src/openapi.ts\`) | \`namespace\` documented with regex pattern; \`/sleep\`, \`/resume\`, \`/export\`, \`/import\` added (they were missing). |
| Python SDK | \`python/memforge/client.py\` + \`resilient.py\`: matching \`namespace\` kwarg. |

## Tests

\`tests/http-api.test.ts\` — new "Namespace support" suite (5 tests): add+consolidate to non-default namespace, scoped query, cross-namespace isolation, 400s on invalid namespace input (POST and GET).

Python SDK tests out of scope — Python test infrastructure isn't in CI.

## Design notes

- **Entities & relationships NOT namespaced** — a single "User Sarah" can appear across namespaces for an agent; duplicating per namespace would fragment the knowledge graph. Same decision as C.1.
- **Export is self-contained** — entities + relationships included in every namespace-scoped export so a JSONL dump can be re-imported anywhere (even into a fresh agent).
- **Cache keys include namespace** — stats/timeline/resume cached responses no longer leak across namespaces.
- **Sleep is agent-wide** — documented in SleepSchema comment, MCP tool description, and SDK docstrings.

## Test plan

- [ ] CI \`type-check\`, \`lint\`, \`build\` pass
- [ ] CI \`test-integration\` (Node 20 + 22) — includes HTTP suite with new namespace tests
- [ ] CI \`test-rls\` still passes
- [ ] Load tests skipped on PR
- [ ] Next tag (beta.4+) will validate Trusted Publishing E2E

## ROADMAP

#16 marked ✅ DONE (backend via PR #100, public surface via this PR).