### PR TITLE
feat(cold-tier): search + restoration for audit/recovery (Sprint D, #14)

### DIFF
--- a/python/memforge/client.py
+++ b/python/memforge/client.py
@@ -237,8 +237,6 @@ class MemForgeClient:
             body["revisionThreshold"] = revision_threshold
         if include_reflection is not None:
             body["includeReflection"] = include_reflection
-        if namespace:
-            body["namespace"] = namespace
         raw = await self._post(f"/memory/{agent_id}/sleep", body)
         return SleepCycleResult(**raw)
 
@@ -278,6 +276,47 @@ class MemForgeClient:
     async def deduplicate_entities(self, agent_id: str, threshold: float = 0.7) -> dict[str, Any]:
         """Merge duplicate entities in the knowledge graph."""
         return await self._post(f"/memory/{agent_id}/dedup-entities", {"threshold": threshold})
+
+    # ── Cold Tier ─────────────────────────────────────────────────────────
+
+    async def search_cold_tier(
+        self,
+        agent_id: str,
+        *,
+        q: str | None = None,
+        namespace: str | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        source_table: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Search archived cold tier memories. Use for audit, recovery, and compliance."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if q:
+            params["q"] = q
+        if namespace:
+            params["namespace"] = namespace
+        if from_date:
+            params["from"] = from_date
+        if to_date:
+            params["to"] = to_date
+        if source_table:
+            params["source_table"] = source_table
+        return await self._get(f"/memory/{agent_id}/cold", params)
+
+    async def restore_cold_tier(
+        self,
+        agent_id: str,
+        cold_id: int | str,
+        *,
+        namespace: str | None = None,
+    ) -> dict[str, Any]:
+        """Restore a cold tier row to warm tier. Non-destructive — cold row is preserved."""
+        body: dict[str, Any] = {"cold_id": str(cold_id)}
+        if namespace:
+            body["namespace"] = namespace
+        return await self._post(f"/memory/{agent_id}/restore", body)
 
     # ── Shared Pools (Phase 3) ─────────────────────────────────────────────
 

--- a/python/memforge/resilient.py
+++ b/python/memforge/resilient.py
@@ -166,6 +166,20 @@ class ResilientMemForgeClient:
             self._handle(e)
             return None
 
+    async def search_cold_tier(self, agent_id: str, **kwargs: Any) -> dict[str, Any]:
+        try:
+            return await self._client.search_cold_tier(agent_id, **kwargs)
+        except Exception as e:
+            self._handle(e)
+            return {"rows": [], "total": 0}
+
+    async def restore_cold_tier(self, agent_id: str, cold_id: int | str, **kwargs: Any) -> dict[str, Any] | None:
+        try:
+            return await self._client.restore_cold_tier(agent_id, cold_id, **kwargs)
+        except Exception as e:
+            self._handle(e)
+            return None
+
     async def health(self) -> dict[str, Any] | None:
         try:
             return await self._client.health()

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,7 +18,7 @@ import {
   httpRequestDurationSeconds,
 } from './metrics.js';
 import { bearerAuth, requireScope } from './auth.js';
-import { NamespaceSchema, AddMemorySchema, ConsolidateSchema, SleepSchema } from './schemas.js';
+import { NamespaceSchema, AddMemorySchema, ConsolidateSchema, SleepSchema, ColdTierSearchSchema, ColdTierRestoreSchema } from './schemas.js';
 import {
   cacheGet,
   cacheSet,
@@ -1014,6 +1014,89 @@ export function createApp(deps: AppDependencies): express.Express {
       ok(res, state);
     } catch (err) {
       fail(res, 500, (err as Error).message);
+    }
+  });
+
+  /**
+   * GET /memory/:agentId/cold
+   * Query params: q?, namespace?, from?, to?, source_table?, limit?, offset?
+   */
+  app.get('/memory/:agentId/cold', requireScope('memforge:read'), async (req: Request, res: Response) => {
+    const parsed = ColdTierSearchSchema.safeParse({
+      q: req.query['q'],
+      namespace: req.query['namespace'],
+      from: req.query['from'],
+      to: req.query['to'],
+      source_table: req.query['source_table'],
+      limit: req.query['limit'],
+      offset: req.query['offset'],
+    });
+
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      fail(res, 400, issue?.message ?? 'Invalid query parameters');
+      return;
+    }
+
+    const { q, namespace, from, to, source_table, limit, offset } = parsed.data;
+
+    let agentId: string;
+    try {
+      agentId = getAgentId(req);
+    } catch (err) {
+      fail(res, 400, (err as Error).message);
+      return;
+    }
+
+    try {
+      const result = await manager.searchColdTier(agentId, {
+        q,
+        namespace,
+        from: from ? new Date(from) : undefined,
+        to: to ? new Date(to) : undefined,
+        sourceTable: source_table,
+        limit,
+        offset,
+      });
+      ok(res, result);
+    } catch (err) {
+      fail(res, 500, (err as Error).message);
+    }
+  });
+
+  /**
+   * POST /memory/:agentId/restore
+   * Body: { cold_id: string|number, namespace?: string }
+   */
+  app.post('/memory/:agentId/restore', requireScope('memforge:write'), async (req: Request, res: Response) => {
+    const parsed = ColdTierRestoreSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      fail(res, 400, issue?.message ?? 'Invalid request body');
+      return;
+    }
+
+    const { cold_id, namespace } = parsed.data;
+
+    let agentId: string;
+    try {
+      agentId = getAgentId(req);
+    } catch (err) {
+      fail(res, 400, (err as Error).message);
+      return;
+    }
+
+    try {
+      const result = await manager.restoreColdTier(agentId, BigInt(cold_id), namespace ? { namespace } : {});
+      void invalidateAgent(agentId);
+      ok(res, result);
+    } catch (err) {
+      const e = err as Error & { code?: string };
+      if (e.code === 'NOT_FOUND') {
+        fail(res, 404, e.message);
+      } else {
+        fail(res, 500, e.message);
+      }
     }
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,6 +32,8 @@ import type {
   ResumeContext,
   EntityDeduplicationResult,
   HealthStatus,
+  ColdTierSearchResult,
+  RestoreColdTierResult,
 } from './types.js';
 
 // ─── Config ──────────────────────────────────────────────────────────────────
@@ -225,6 +227,37 @@ export class MemForgeClient {
     return this.post<ActiveMemoryResult>(`/memory/${enc(agentId)}/active-recall`, { context, limit });
   }
 
+  // ─── Cold Tier ────────────────────────────────────────────────────────
+
+  /** Search archived cold tier memories. Use for audit, recovery, and compliance. */
+  async searchColdTier(agentId: string, opts: {
+    q?: string;
+    namespace?: string;
+    from?: string;
+    to?: string;
+    sourceTable?: 'hot_tier' | 'warm_tier';
+    limit?: number;
+    offset?: number;
+  } = {}): Promise<ColdTierSearchResult> {
+    const params = new URLSearchParams();
+    if (opts.q) params.set('q', opts.q);
+    if (opts.namespace) params.set('namespace', opts.namespace);
+    if (opts.from) params.set('from', opts.from);
+    if (opts.to) params.set('to', opts.to);
+    if (opts.sourceTable) params.set('source_table', opts.sourceTable);
+    if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+    if (opts.offset !== undefined) params.set('offset', String(opts.offset));
+    const qs = params.toString();
+    return this.get<ColdTierSearchResult>(`/memory/${enc(agentId)}/cold${qs ? '?' + qs : ''}`);
+  }
+
+  /** Restore a cold tier row to warm tier. Non-destructive — the cold row is preserved. */
+  async restoreColdTier(agentId: string, coldId: number | bigint | string, opts: { namespace?: string } = {}): Promise<RestoreColdTierResult> {
+    const body: Record<string, unknown> = { cold_id: String(coldId) };
+    if (opts.namespace) body['namespace'] = opts.namespace;
+    return this.post<RestoreColdTierResult>(`/memory/${enc(agentId)}/restore`, body);
+  }
+
   // ─── System ─────────────────────────────────────────────────────────────
 
   /** Health check. */
@@ -378,6 +411,14 @@ export class ResilientMemForgeClient {
 
   async activeRecall(agentId: string, context: string, limit?: number): Promise<ActiveMemoryResult> {
     return this.safe('activeRecall', () => this.client.activeRecall(agentId, context, limit), { agent_id: agentId, memories: [], procedures: [] });
+  }
+
+  async searchColdTier(agentId: string, opts: Parameters<MemForgeClient['searchColdTier']>[1] = {}): Promise<ColdTierSearchResult> {
+    return this.safe('searchColdTier', () => this.client.searchColdTier(agentId, opts), { rows: [], total: 0 });
+  }
+
+  async restoreColdTier(agentId: string, coldId: number | bigint | string, opts: Parameters<MemForgeClient['restoreColdTier']>[2] = {}): Promise<RestoreColdTierResult | null> {
+    return this.safe('restoreColdTier', () => this.client.restoreColdTier(agentId, coldId, opts), null);
   }
 
   async health(): Promise<HealthStatus | null> {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -251,6 +251,37 @@ const TOOLS: MCPToolDefinition[] = [
       required: ['agent_id', 'context'],
     },
   },
+  {
+    name: 'memforge_cold_search',
+    description: 'Search archived (cold tier) memories. Use for audit, recovery, and compliance. Returns rows still within retention window.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agent_id: { type: 'string', description: 'Agent/session identifier' },
+        q: { type: 'string', description: 'Substring match on content (case-insensitive)' },
+        namespace: { type: 'string', description: 'Filter by namespace (default: "default")' },
+        from: { type: 'string', description: 'Filter archived_at >= from (ISO 8601)' },
+        to: { type: 'string', description: 'Filter archived_at <= to (ISO 8601)' },
+        source_table: { type: 'string', enum: ['hot_tier', 'warm_tier'], description: 'Filter by source table' },
+        limit: { type: 'integer', description: 'Max results (default 50, max 500)' },
+        offset: { type: 'integer', description: 'Rows to skip for pagination' },
+      },
+      required: ['agent_id'],
+    },
+  },
+  {
+    name: 'memforge_cold_restore',
+    description: 'Restore a cold tier row to warm tier for reactivation. Non-destructive — the cold row is preserved for audit.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agent_id: { type: 'string', description: 'Agent/session identifier' },
+        cold_id: { type: 'string', description: 'cold_tier row id to restore' },
+        namespace: { type: 'string', description: 'Override namespace on restore (defaults to cold row\'s original namespace)' },
+      },
+      required: ['agent_id', 'cold_id'],
+    },
+  },
 ];
 
 // ─── Input Validation ────────────────────────────────────────────────────────
@@ -369,6 +400,22 @@ async function executeTool(client: MemForgeClient, name: string, args: Record<st
 
     case 'memforge_active_recall':
       return client.activeRecall(agentId, args['context'] as string, args['limit'] as number | undefined);
+
+    case 'memforge_cold_search':
+      return client.searchColdTier(agentId, {
+        q: args['q'] as string | undefined,
+        namespace: args['namespace'] as string | undefined,
+        from: args['from'] as string | undefined,
+        to: args['to'] as string | undefined,
+        sourceTable: args['source_table'] as 'hot_tier' | 'warm_tier' | undefined,
+        limit: args['limit'] as number | undefined,
+        offset: args['offset'] as number | undefined,
+      });
+
+    case 'memforge_cold_restore':
+      return client.restoreColdTier(agentId, args['cold_id'] as string, {
+        namespace: args['namespace'] as string | undefined,
+      });
 
     default:
       throw new Error(`Unknown tool: ${name}`);

--- a/src/memory-manager.ts
+++ b/src/memory-manager.ts
@@ -49,6 +49,10 @@ import type {
   OutcomeType,
   MemoryHints,
   SqlParam,
+  ColdTierRow,
+  ColdTierSearchOptions,
+  ColdTierSearchResult,
+  RestoreColdTierResult,
 } from './types.js';
 const DEFAULT_NAMESPACE = 'default';
 
@@ -2825,5 +2829,133 @@ Guidelines:
     }
 
     return { imported, errors };
+  }
+
+  // ─── Cold Tier Search ────────────────────────────────────────────────────
+
+  async searchColdTier(agentId: string, opts: ColdTierSearchOptions = {}): Promise<ColdTierSearchResult> {
+    this.assertAgentId(agentId);
+    const ns = resolveNamespace(opts.namespace);
+    const limit = Math.min(opts.limit ?? 50, 500);
+    const offset = opts.offset ?? 0;
+
+    const params: SqlParam[] = [agentId, ns];
+    const conditions: string[] = ['agent_id = $1', 'namespace = $2'];
+
+    if (opts.q) {
+      params.push(`%${escapeLike(opts.q)}%`);
+      conditions.push(`content ILIKE $${params.length}`);
+    }
+    if (opts.from) {
+      params.push(opts.from);
+      conditions.push(`archived_at >= $${params.length}`);
+    }
+    if (opts.to) {
+      params.push(opts.to);
+      conditions.push(`archived_at <= $${params.length}`);
+    }
+    if (opts.sourceTable) {
+      params.push(opts.sourceTable);
+      conditions.push(`source_table = $${params.length}`);
+    }
+
+    const where = conditions.join(' AND ');
+
+    const [dataResult, countResult] = await Promise.all([
+      this.pool.query<ColdTierRow>(
+        `SELECT id, agent_id, source_table, source_id, content, metadata, archived_at, original_created_at, namespace
+         FROM cold_tier
+         WHERE ${where}
+         ORDER BY archived_at DESC
+         LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+        [...params, limit, offset],
+      ),
+      this.pool.query<{ total: string }>(
+        `SELECT count(*) AS total FROM cold_tier WHERE ${where}`,
+        params,
+      ),
+    ]);
+
+    return {
+      rows: dataResult.rows,
+      total: parseInt(countResult.rows[0]!.total, 10),
+    };
+  }
+
+  // ─── Cold Tier Restore ───────────────────────────────────────────────────
+
+  async restoreColdTier(agentId: string, coldTierId: bigint, opts: { namespace?: string } = {}): Promise<RestoreColdTierResult> {
+    this.assertAgentId(agentId);
+
+    const { rows: coldRows } = await this.pool.query<ColdTierRow>(
+      `SELECT id, agent_id, source_table, source_id, content, metadata, archived_at, original_created_at, namespace
+       FROM cold_tier WHERE id = $1 AND agent_id = $2`,
+      [coldTierId, agentId],
+    );
+
+    if (coldRows.length === 0) {
+      throw Object.assign(
+        new Error(`cold_tier row ${coldTierId} not found for agent ${agentId}`),
+        { code: 'NOT_FOUND' },
+      );
+    }
+
+    const cold = coldRows[0]!;
+    const targetNamespace = opts.namespace ? resolveNamespace(opts.namespace) : cold.namespace;
+
+    const restoredMetadata: Record<string, unknown> = {
+      ...cold.metadata,
+      _restored_from_cold_id: String(cold.id),
+    };
+
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const { rows: warmRows } = await client.query<{ id: bigint }>(
+        `INSERT INTO warm_tier
+           (agent_id, content, source_hot_ids, metadata, time_start, time_end,
+            importance, confidence, namespace)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+         RETURNING id`,
+        [
+          agentId,
+          cold.content,
+          [],
+          JSON.stringify(restoredMetadata),
+          cold.original_created_at,
+          cold.original_created_at,
+          0.5,
+          0.5,
+          targetNamespace,
+        ],
+      );
+
+      const warmId = warmRows[0]!.id;
+
+      if (this.audit) {
+        await this.audit.record(
+          agentId, 'warm_tier', warmId, 'create',
+          null, cold.content,
+          { restored_from_cold_id: String(cold.id), namespace: targetNamespace },
+          'api', null, client,
+        );
+      }
+
+      await client.query('COMMIT');
+
+      log.info({ agentId, coldTierId: String(cold.id), warmId: String(warmId), namespace: targetNamespace }, 'cold tier row restored to warm tier');
+
+      return {
+        warm_tier_id: warmId,
+        cold_tier_id: cold.id,
+        content: cold.content,
+      };
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
   }
 }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -437,6 +437,63 @@ export function buildOpenApiSpec(port: number): Record<string, unknown> {
           },
         },
       },
+      '/memory/{agentId}/cold': {
+        get: {
+          summary: 'Search cold tier (archived memories)',
+          tags: ['Memory'],
+          parameters: [
+            { name: 'agentId', in: 'path', required: true, schema: { type: 'string' } },
+            { name: 'q', in: 'query', schema: { type: 'string' }, description: 'Substring match on content (case-insensitive)' },
+            { name: 'namespace', in: 'query', schema: { type: 'string', pattern: '^[a-z0-9][a-z0-9_-]*$' }, description: 'Filter by namespace (default: "default")' },
+            { name: 'from', in: 'query', schema: { type: 'string', format: 'date-time' }, description: 'Filter archived_at >= from' },
+            { name: 'to', in: 'query', schema: { type: 'string', format: 'date-time' }, description: 'Filter archived_at <= to' },
+            { name: 'source_table', in: 'query', schema: { type: 'string', enum: ['hot_tier', 'warm_tier'] }, description: 'Filter by source table' },
+            { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 500, default: 50 } },
+            { name: 'offset', in: 'query', schema: { type: 'integer', minimum: 0, default: 0 }, description: 'Rows to skip for pagination' },
+          ],
+          responses: {
+            '200': {
+              description: 'Matching cold tier rows with total count for pagination',
+              content: { 'application/json': { schema: { '$ref': '#/components/schemas/OkResponse' } } },
+            },
+            '400': { '$ref': '#/components/responses/BadRequest' },
+            '500': { '$ref': '#/components/responses/InternalError' },
+          },
+        },
+      },
+      '/memory/{agentId}/restore': {
+        post: {
+          summary: 'Restore a cold tier row to warm tier',
+          tags: ['Memory'],
+          parameters: [
+            { name: 'agentId', in: 'path', required: true, schema: { type: 'string' } },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['cold_id'],
+                  properties: {
+                    cold_id: { oneOf: [{ type: 'string', pattern: '^\\d+$' }, { type: 'integer', minimum: 1 }], description: 'cold_tier row id to restore' },
+                    namespace: { type: 'string', pattern: '^[a-z0-9][a-z0-9_-]*$', description: 'Override namespace on restore (defaults to cold row\'s original namespace)' },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            '200': {
+              description: 'New warm_tier row id and restored content',
+              content: { 'application/json': { schema: { '$ref': '#/components/schemas/OkResponse' } } },
+            },
+            '400': { '$ref': '#/components/responses/BadRequest' },
+            '404': { '$ref': '#/components/responses/NotFound' },
+            '500': { '$ref': '#/components/responses/InternalError' },
+          },
+        },
+      },
       '/admin/cache/stats': {
         get: {
           summary: 'Cache statistics (admin)',

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -61,6 +61,21 @@ export const ImportSchema = z.object({
   namespace: NamespaceSchema.optional(),
 });
 
+export const ColdTierSearchSchema = z.object({
+  q: z.string().max(10_000).optional(),
+  namespace: NamespaceSchema.optional(),
+  from: z.string().datetime({ offset: true }).optional(),
+  to: z.string().datetime({ offset: true }).optional(),
+  source_table: z.enum(['hot_tier', 'warm_tier']).optional(),
+  limit: z.coerce.number().int().min(1).max(500).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export const ColdTierRestoreSchema = z.object({
+  cold_id: z.union([z.string().regex(/^\d+$/), z.number().int().positive()]),
+  namespace: NamespaceSchema.optional(),
+});
+
 // ─── LLM Response Schemas ───────────────────────────────────────────────────
 
 export const ConsolidationSummarySchema = z.object({

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -228,6 +228,37 @@ export const tools: ToolDefinition[] = [
       required: ['agent_id', 'context'],
     },
   },
+  {
+    name: 'memforge_cold_search',
+    description: 'Search archived (cold tier) memories. Use for audit, recovery, and compliance. Returns rows still within the retention window.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        agent_id: { type: 'string', description: 'The agent/session identifier' },
+        q: { type: 'string', description: 'Substring match on content (case-insensitive)' },
+        namespace: { type: 'string', description: 'Filter by namespace; defaults to "default"' },
+        from: { type: 'string', format: 'date-time', description: 'Filter archived_at >= from' },
+        to: { type: 'string', format: 'date-time', description: 'Filter archived_at <= to' },
+        source_table: { type: 'string', enum: ['hot_tier', 'warm_tier'], description: 'Filter by origin tier' },
+        limit: { type: 'integer', description: 'Max results (default 50, max 500)', minimum: 1, maximum: 500 },
+        offset: { type: 'integer', description: 'Rows to skip for pagination', minimum: 0 },
+      },
+      required: ['agent_id'],
+    },
+  },
+  {
+    name: 'memforge_cold_restore',
+    description: 'Restore a cold tier row back to warm tier for reactivation. Non-destructive — the original cold row is preserved for audit.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        agent_id: { type: 'string', description: 'The agent/session identifier' },
+        cold_id: { type: 'string', description: 'cold_tier row id to restore' },
+        namespace: { type: 'string', description: 'Override namespace on restore; defaults to cold row\'s original namespace' },
+      },
+      required: ['agent_id', 'cold_id'],
+    },
+  },
 ];
 
 /** Convert MemForge tool definitions to OpenAI function calling format. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -354,6 +354,49 @@ export interface ClearResult {
   warm_archived: number;
 }
 
+export interface ColdTierRow {
+  id: bigint;
+  agent_id: string;
+  source_table: 'hot_tier' | 'warm_tier';
+  source_id: bigint;
+  content: string;
+  metadata: Record<string, unknown>;
+  archived_at: Date;
+  original_created_at: Date;
+  namespace: string;
+}
+
+export interface ColdTierSearchOptions {
+  /** Substring match on content (ILIKE '%q%') */
+  q?: string;
+  /** Filter to a specific namespace (default: 'default') */
+  namespace?: string;
+  /** Filter archived_at >= from */
+  from?: Date;
+  /** Filter archived_at <= to */
+  to?: Date;
+  /** Filter by source table */
+  sourceTable?: 'hot_tier' | 'warm_tier';
+  /** Max rows to return (default 50, max 500) */
+  limit?: number;
+  /** Rows to skip for pagination */
+  offset?: number;
+}
+
+export interface ColdTierSearchResult {
+  rows: ColdTierRow[];
+  /** Total matching rows without limit/offset — use for pagination */
+  total: number;
+}
+
+export interface RestoreColdTierResult {
+  /** New warm_tier row id */
+  warm_tier_id: bigint;
+  /** Cold tier row that was the source */
+  cold_tier_id: bigint;
+  content: string;
+}
+
 // ─── Stats ───────────────────────────────────────────────────────────────────
 
 export interface AgentStats {

--- a/tests/cold-tier-search.test.ts
+++ b/tests/cold-tier-search.test.ts
@@ -1,0 +1,233 @@
+// MemForge — Cold Tier Search & Restore Tests (Sprint D, Phase 2, Issue #14)
+//
+// Run: node --import tsx/esm --test tests/cold-tier-search.test.ts
+//
+// WARNING: Requires DATABASE_URL pointing to a test database with schema applied.
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { Pool } from 'pg';
+
+const { MemoryManager } = await import('../src/memory-manager.js');
+const { AuditChain } = await import('../src/audit.js');
+const { NoOpEmbeddingProvider } = await import('../src/embedding.js');
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+if (!DATABASE_URL) {
+  console.error('[test] DATABASE_URL is required — set it to a test database');
+  process.exit(1);
+}
+
+const AGENT = 'test-cold-search-agent';
+
+const pool = new Pool({ connectionString: DATABASE_URL });
+const auditChain = new AuditChain(pool);
+
+const manager = new MemoryManager({
+  databaseUrl: DATABASE_URL,
+  autoRegisterAgents: true,
+  embeddingProvider: new NoOpEmbeddingProvider(),
+  llmProvider: null,
+  sleepCycle: {
+    tokenBudget: 100_000,
+    evictionThreshold: 0.1,
+    revisionThreshold: 0.4,
+    includeReflection: false,
+    weights: { recency: 0.25, frequency: 0.20, centrality: 0.20, reflection: 0.15, stability: 0.20 },
+  },
+  auditChain,
+});
+
+async function ensureAgent(): Promise<void> {
+  await pool.query(
+    `INSERT INTO agents (id, metadata) VALUES ($1, '{}') ON CONFLICT (id) DO NOTHING`,
+    [AGENT],
+  );
+}
+
+async function insertColdRow(opts: {
+  content: string;
+  namespace?: string;
+  archivedAt?: Date;
+  sourceTable?: 'hot_tier' | 'warm_tier';
+}): Promise<bigint> {
+  const ts = opts.archivedAt ?? new Date();
+  const { rows } = await pool.query<{ id: bigint }>(
+    `INSERT INTO cold_tier (agent_id, source_table, source_id, content, metadata, archived_at, original_created_at, namespace)
+     VALUES ($1, $2, 1, $3, '{}', $4, $4, $5)
+     RETURNING id`,
+    [AGENT, opts.sourceTable ?? 'warm_tier', opts.content, ts, opts.namespace ?? 'default'],
+  );
+  return rows[0]!.id;
+}
+
+async function cleanup(): Promise<void> {
+  await pool.query(`DELETE FROM audit_chain WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM warm_tier WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM cold_tier WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM agents WHERE id = $1`, [AGENT]);
+}
+
+// ─── Substring search ────────────────────────────────────────────────────────
+
+describe('searchColdTier — substring match', () => {
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    await insertColdRow({ content: 'The user prefers dark mode' });
+    await insertColdRow({ content: 'Project deadline is Friday' });
+    await insertColdRow({ content: 'API key rotation scheduled' });
+  });
+
+  after(cleanup);
+
+  it('returns only the row whose content matches the q substring', async () => {
+    const result = await manager.searchColdTier(AGENT, { q: 'dark mode' });
+
+    assert.equal(result.total, 1);
+    assert.equal(result.rows.length, 1);
+    assert.ok(result.rows[0]!.content.includes('dark mode'));
+  });
+});
+
+// ─── Namespace filter ────────────────────────────────────────────────────────
+
+describe('searchColdTier — namespace filter', () => {
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    await insertColdRow({ content: 'alpha memory 1', namespace: 'alpha' });
+    await insertColdRow({ content: 'alpha memory 2', namespace: 'alpha' });
+    await insertColdRow({ content: 'beta memory 1', namespace: 'beta' });
+  });
+
+  after(cleanup);
+
+  it('returns only rows in the requested namespace', async () => {
+    const result = await manager.searchColdTier(AGENT, { namespace: 'alpha' });
+
+    assert.equal(result.total, 2);
+    assert.equal(result.rows.length, 2);
+    assert.ok(result.rows.every((r) => r.namespace === 'alpha'));
+  });
+});
+
+// ─── Date range filter ───────────────────────────────────────────────────────
+
+describe('searchColdTier — date range filter', () => {
+  const t0 = new Date('2024-01-01T00:00:00Z');
+  const t1 = new Date('2024-06-01T00:00:00Z');
+  const t2 = new Date('2024-12-01T00:00:00Z');
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    await insertColdRow({ content: 'early row', archivedAt: t0 });
+    await insertColdRow({ content: 'mid row', archivedAt: t1 });
+    await insertColdRow({ content: 'late row', archivedAt: t2 });
+  });
+
+  after(cleanup);
+
+  it('returns only rows within the from/to range', async () => {
+    const from = new Date('2024-03-01T00:00:00Z');
+    const to = new Date('2024-09-01T00:00:00Z');
+
+    const result = await manager.searchColdTier(AGENT, { from, to });
+
+    assert.equal(result.total, 1);
+    assert.equal(result.rows.length, 1);
+    assert.ok(result.rows[0]!.content.includes('mid row'));
+  });
+});
+
+// ─── Pagination ──────────────────────────────────────────────────────────────
+
+describe('searchColdTier — pagination via limit/offset', () => {
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    // Insert 10 rows with deterministic ordering via archived_at
+    for (let i = 0; i < 10; i++) {
+      const ts = new Date(Date.now() - i * 60_000);
+      await insertColdRow({ content: `row ${i}`, archivedAt: ts });
+    }
+  });
+
+  after(cleanup);
+
+  it('returns the correct slice for limit=3, offset=3', async () => {
+    const full = await manager.searchColdTier(AGENT, { limit: 10 });
+    const page = await manager.searchColdTier(AGENT, { limit: 3, offset: 3 });
+
+    assert.equal(full.total, 10);
+    assert.equal(page.rows.length, 3);
+    assert.equal(page.total, 10);
+
+    // Slice from the full result to verify correct rows returned
+    const expectedIds = full.rows.slice(3, 6).map((r) => r.id);
+    const actualIds = page.rows.map((r) => r.id);
+    assert.deepEqual(actualIds, expectedIds);
+  });
+});
+
+// ─── Restore round-trip ──────────────────────────────────────────────────────
+
+describe('restoreColdTier — round-trip', () => {
+  let coldId: bigint;
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    coldId = await insertColdRow({ content: 'Restored memory content', namespace: 'alpha' });
+  });
+
+  after(cleanup);
+
+  it('creates a warm_tier row with correct content and audit metadata; cold row survives', async () => {
+    const result = await manager.restoreColdTier(AGENT, coldId);
+
+    // Warm row exists with matching content
+    const { rows: warmRows } = await pool.query<{ content: string; namespace: string; metadata: Record<string, unknown> }>(
+      `SELECT content, namespace, metadata FROM warm_tier WHERE id = $1 AND agent_id = $2`,
+      [result.warm_tier_id, AGENT],
+    );
+
+    assert.equal(warmRows.length, 1);
+    assert.equal(warmRows[0]!.content, 'Restored memory content');
+    assert.equal(warmRows[0]!.namespace, 'alpha');
+    assert.equal(String((warmRows[0]!.metadata as Record<string, unknown>)['_restored_from_cold_id']), String(coldId));
+
+    // Cold row still present — non-destructive
+    const { rows: coldRows } = await pool.query<{ id: bigint }>(
+      `SELECT id FROM cold_tier WHERE id = $1 AND agent_id = $2`,
+      [coldId, AGENT],
+    );
+    assert.equal(coldRows.length, 1);
+  });
+});
+
+// ─── Restore 404 ────────────────────────────────────────────────────────────
+
+describe('restoreColdTier — not found', () => {
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+  });
+
+  after(cleanup);
+
+  it('throws NOT_FOUND error for a non-existent cold_id', async () => {
+    const nonExistentId = BigInt(9_999_999_999);
+
+    await assert.rejects(
+      () => manager.restoreColdTier(AGENT, nonExistentId),
+      (err: Error & { code?: string }) => {
+        assert.equal(err.code, 'NOT_FOUND');
+        return true;
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Cold tier was previously write-only. This PR adds **search** and **non-destructive restoration** to complete the audit/recovery story for the archive tier. Sprint D of Phase 2.

**Fixes #14.**

## New API

### MemoryManager

- \`searchColdTier(agentId, { q?, namespace?, from?, to?, sourceTable?, limit?, offset? })\` — filter by content substring, namespace, archive-timestamp range, source table. Returns \`{ rows, total }\`.
- \`restoreColdTier(agentId, coldTierId, { namespace? })\` — copies a cold row back into warm_tier with \`_restored_from_cold_id\` metadata stamp. Cold row is preserved.

### HTTP

- \`GET /memory/:id/cold\` — read-scoped. Query params mirror MemoryManager options.
- \`POST /memory/:id/restore\` — write-scoped. Body: \`{ cold_id, namespace? }\`. 404 if cold_id not found.

### MCP

- \`memforge_cold_search\`, \`memforge_cold_restore\` — terse tool descriptions noting audit/recovery use case.

### TS SDK + Python SDK

- Matching methods on both \`MemForgeClient\` / \`ResilientMemForgeClient\` (TS) and \`MemForgeClient\` / \`ResilientMemForgeClient\` (Python).

## Schema

**No migration.** Existing cold_tier indexes (\`agent_id\`, \`agent_id+namespace\`, \`archived_at\`) cover the filtered search path. A \`tsvector\` GIN index on \`cold_tier.content\` was deliberately NOT added — cold tier is a read-rare archive, write amplification would dominate. Substring search via parameterized \`ILIKE\` with an \`escapeLike\` helper is sufficient for the audit/recovery use case.

## Design notes

- **Restoration is non-destructive.** The cold_tier row is preserved after restore so the audit trail stays intact. Restored warm rows carry \`metadata._restored_from_cold_id = <cold.id>\`.
- **Restored rows get fresh scoring.** \`importance=0.5, confidence=0.5\` so the next sleep cycle re-scores them in context.
- **Namespace override on restore.** \`opts.namespace\` lets an operator move a memory between namespaces (e.g. restore a 'legacy' archive into 'current'). Defaults to the cold row's original namespace.
- **Single-row only.** Bulk restoration is out of scope for this PR.
- **Semantic search deferred.** ILIKE substring is fine for archive lookups; semantic can be added if users demand it.

## Test plan

- [ ] CI \`type-check\`, \`lint\`, \`build\` pass
- [ ] CI \`test-integration\` runs the new \`cold-tier-search.test.ts\` — 6 tests: substring match, namespace filter, date range, limit/offset paging, non-destructive restore round-trip, restore 404
- [ ] Existing retention tests still pass (retention + search both read the same table)
- [ ] Load tests skipped on PR

## Incidental fix

Leftover undefined \`namespace\` reference in \`python/memforge/client.py\`'s \`sleep()\` from the C.2 PR — fixed here since it's in a file I was modifying anyway.