### PR TITLE
feat(sleep-cycle): memory budgeting — per-agent warm_tier hard cap (Sprint E)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,12 @@ SLEEP_CYCLE_REVISION_THRESHOLD=0.4
 # Whether to run reflection as part of sleep cycles (default: true)
 SLEEP_CYCLE_INCLUDE_REFLECTION=true
 
+# Hard cap on warm_tier rows per agent (default: unset or 0 = no cap, opt-in).
+# When an agent exceeds this limit, the sleep cycle archives lowest-importance
+# memories first (not oldest) until exactly this many rows remain.
+# Existing deployments are unaffected when left unset.
+# WARM_TIER_MAX_PER_AGENT=1000
+
 # ─── Temporal Intelligence ───────────────────────────────────────────────────
 
 # Temporal decay rate per hour for query ranking (default: 0 = no decay)

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,6 +66,7 @@ const manager = new MemoryManager({
     coldRetentionDays: process.env['COLD_TIER_RETENTION_DAYS']
       ? Math.max(1, parseInt(process.env['COLD_TIER_RETENTION_DAYS'], 10))
       : undefined,
+    warmTierMaxPerAgent: parseInt(process.env['WARM_TIER_MAX_PER_AGENT'] ?? '0', 10),
     weights: {
       recency: 0.25,
       frequency: 0.20,

--- a/src/sleep-cycle.ts
+++ b/src/sleep-cycle.ts
@@ -86,6 +86,11 @@ export class SleepCycleEngine {
     // Phase 2: Triage
     const { evicted, flaggedIds } = await this.phaseTriage(agentId);
 
+    // Phase 2b: Capacity eviction — enforce per-agent warm_tier hard cap.
+    // Runs after threshold eviction so the threshold pass already removed the
+    // cheapest evictees; we only evict further if the agent is still over cap.
+    const capacityEvicted = await this.phaseCapacityEviction(agentId);
+
     // Phase 2.5: Conflict Resolution — resolve contradicting memories
     const conflictsResolved = await this.phaseConflictResolution(agentId);
 
@@ -146,7 +151,7 @@ export class SleepCycleEngine {
       }
     }
 
-    return {
+    const result: SleepCycleResult = {
       agent_id: agentId,
       phase1_scores_updated: scoresUpdated,
       phase2_evicted: evicted,
@@ -163,6 +168,12 @@ export class SleepCycleEngine {
       tokens_used: tokensUsed,
       duration_ms: Date.now() - start,
     };
+
+    if (capacityEvicted > 0) {
+      result.capacity_evicted = capacityEvicted;
+    }
+
+    return result;
   }
 
   // ─── Phase 0: Autonomous Weight Adaptation ─────────────────────────────────
@@ -385,6 +396,60 @@ export class SleepCycleEngine {
       evicted,
       flaggedIds: flagged.rows.map((r) => r.id),
     };
+  }
+
+  // ─── Phase 2b: Capacity Eviction ──────────────────────────────────────────
+  // Enforces the per-agent warm_tier hard cap (warmTierMaxPerAgent).
+  // Graduation status does not exempt rows — the cap is a hard budget and
+  // value (importance) determines who is archived, not retrieval history.
+
+  private async phaseCapacityEviction(agentId: string): Promise<number> {
+    const cap = this.config.warmTierMaxPerAgent ?? 0;
+    if (!cap) return 0;
+
+    const countResult = await this.pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM warm_tier WHERE agent_id = $1`,
+      [agentId],
+    );
+    const priorCount = parseInt(countResult.rows[0]?.count ?? '0', 10);
+
+    if (priorCount <= cap) return 0;
+
+    const toEvict = priorCount - cap;
+
+    const evictResult = await this.pool.query<{ count: string }>(
+      `WITH candidates AS (
+         SELECT id, content, metadata, consolidated_at, namespace
+         FROM warm_tier
+         WHERE agent_id = $1
+         ORDER BY importance ASC
+         LIMIT $2
+         FOR UPDATE
+       ),
+       moved AS (
+         INSERT INTO cold_tier (agent_id, source_table, source_id, content, metadata, original_created_at, namespace)
+         SELECT $1, 'warm_tier', c.id, c.content, c.metadata, c.consolidated_at, c.namespace
+         FROM candidates c
+         RETURNING source_id
+       ),
+       deleted AS (
+         DELETE FROM warm_tier WHERE agent_id = $1 AND id IN (SELECT id FROM candidates)
+       )
+       SELECT count(*) FROM moved`,
+      [agentId, toEvict],
+    );
+    const capacityEvicted = parseInt(evictResult.rows[0]?.count ?? '0', 10);
+
+    log.info({ agentId, capacityEvicted, cap, priorCount }, 'capacity eviction complete');
+
+    if (this.audit && capacityEvicted > 0) {
+      void this.audit.recordBatch(agentId, 'warm_tier', 'evict',
+        { evicted_count: capacityEvicted, reason: 'capacity', cap, prior_count: priorCount },
+        'sleep_cycle',
+      ).catch((err) => log.error({ err }, 'capacity eviction audit failed'));
+    }
+
+    return capacityEvicted;
   }
 
   // ─── Phase 3: Revision ─────────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -302,6 +302,8 @@ export interface SleepCycleResult {
   audit_records_archived: number;
   tokens_used: number;
   duration_ms: number;
+  /** Rows evicted by capacity budgeting (optional — absent when cap is disabled) */
+  capacity_evicted?: number;
 }
 
 export interface SleepCycleConfig {
@@ -317,6 +319,13 @@ export interface SleepCycleConfig {
   coldRetentionDays?: number;
   /** Max revisions per sleep cycle — caps LLM spending per run. */
   maxRevisionsPerCycle?: number;
+  /**
+   * Hard cap on warm_tier rows per agent. When set, capacity-based eviction runs
+   * after threshold eviction: the bottom (count - cap) rows by importance are
+   * archived to cold_tier until exactly cap rows remain. Unset or 0 disables the
+   * cap entirely so existing deployments are unaffected.
+   */
+  warmTierMaxPerAgent?: number;
   /** Importance score weights */
   weights: {
     recency: number;

--- a/tests/memory-budgeting.test.ts
+++ b/tests/memory-budgeting.test.ts
@@ -1,0 +1,307 @@
+// MemForge — Memory Budgeting Tests (Sprint E, Phase 2)
+//
+// Tests the per-agent warm_tier hard cap enforced during the sleep cycle.
+// All tests insert rows with explicit importance values so behaviour is
+// deterministic — no sleeps, no time-travel in Postgres.
+//
+// Run: node --import tsx/esm --test tests/memory-budgeting.test.ts
+//
+// WARNING: Requires DATABASE_URL pointing to a test database with schema applied.
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { Pool } from 'pg';
+
+const { MemoryManager } = await import('../src/memory-manager.js');
+const { MockLLMProvider } = await import('./mocks/mock-llm-provider.js');
+const { NoOpEmbeddingProvider } = await import('../src/embedding.js');
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+if (!DATABASE_URL) {
+  console.error('[test] DATABASE_URL is required — set it to a test database');
+  process.exit(1);
+}
+
+const AGENT = 'test-budget-agent';
+
+const pool = new Pool({ connectionString: DATABASE_URL });
+const mockLlm = new MockLLMProvider();
+
+async function ensureAgent(): Promise<void> {
+  await pool.query(
+    `INSERT INTO agents (id, metadata) VALUES ($1, '{}') ON CONFLICT (id) DO NOTHING`,
+    [AGENT],
+  );
+}
+
+async function cleanup(): Promise<void> {
+  await pool.query(`DELETE FROM audit_chain WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM memory_revisions WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM retrieval_log WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM warm_tier_entities WHERE warm_tier_id IN (SELECT id FROM warm_tier WHERE agent_id = $1)`, [AGENT]);
+  await pool.query(`DELETE FROM cold_tier WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM warm_tier WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM agents WHERE id = $1`, [AGENT]);
+}
+
+/** Insert N warm rows with importance values spread evenly across [minImp, maxImp]. */
+async function insertWarmRows(opts: {
+  count: number;
+  namespace?: string;
+  graduated?: boolean;
+  importances?: number[];
+}): Promise<void> {
+  const ns = opts.namespace ?? 'default';
+  const importances = opts.importances
+    ?? Array.from({ length: opts.count }, (_, i) =>
+        parseFloat(((i + 1) / opts.count).toFixed(4)));
+  for (const imp of importances) {
+    await pool.query(
+      `INSERT INTO warm_tier (agent_id, content, source_hot_ids, metadata, importance, graduated, namespace)
+       VALUES ($1, $2, '{}', '{}', $3, $4, $5)`,
+      [AGENT, `memory with importance ${imp}`, imp, opts.graduated ?? false, ns],
+    );
+  }
+}
+
+async function warmCount(): Promise<number> {
+  const { rows } = await pool.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM warm_tier WHERE agent_id = $1`,
+    [AGENT],
+  );
+  return parseInt(rows[0]!.count, 10);
+}
+
+async function coldCount(): Promise<number> {
+  const { rows } = await pool.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM cold_tier WHERE agent_id = $1`,
+    [AGENT],
+  );
+  return parseInt(rows[0]!.count, 10);
+}
+
+function makeManager(sleepOverrides: { warmTierMaxPerAgent?: number; evictionThreshold?: number }): InstanceType<typeof MemoryManager> {
+  return new MemoryManager({
+    databaseUrl: DATABASE_URL!,
+    autoRegisterAgents: true,
+    embeddingProvider: new NoOpEmbeddingProvider(),
+    llmProvider: mockLlm,
+    sleepCycle: {
+      tokenBudget: 100_000,
+      // Default threshold is low enough not to interfere unless explicitly raised in a test
+      evictionThreshold: sleepOverrides.evictionThreshold ?? 0.0,
+      revisionThreshold: 0.0,
+      includeReflection: false,
+      weights: { recency: 0.25, frequency: 0.20, centrality: 0.20, reflection: 0.15, stability: 0.20 },
+      warmTierMaxPerAgent: sleepOverrides.warmTierMaxPerAgent,
+    },
+  });
+}
+
+// ─── 1. Cap disabled (default) ───────────────────────────────────────────────
+
+describe('memory budgeting — cap disabled (default)', () => {
+  const manager = makeManager({ warmTierMaxPerAgent: 0 });
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    await insertWarmRows({ count: 50 });
+  });
+  after(cleanup);
+
+  it('does not evict any rows when cap is 0', async () => {
+    const result = await manager.sleep(AGENT);
+
+    assert.equal(result.capacity_evicted, undefined, 'capacity_evicted must be absent');
+    assert.equal(await warmCount(), 50, 'all 50 rows must remain');
+  });
+});
+
+// ─── 2. Within cap ───────────────────────────────────────────────────────────
+
+describe('memory budgeting — within cap', () => {
+  const manager = makeManager({ warmTierMaxPerAgent: 20 });
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    await insertWarmRows({ count: 10 });
+  });
+  after(cleanup);
+
+  it('does not evict when row count is below cap', async () => {
+    const result = await manager.sleep(AGENT);
+
+    assert.equal(result.capacity_evicted, undefined);
+    assert.equal(await warmCount(), 10);
+  });
+});
+
+// ─── 3. Exactly at cap ───────────────────────────────────────────────────────
+
+describe('memory budgeting — exactly at cap', () => {
+  const manager = makeManager({ warmTierMaxPerAgent: 20 });
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    await insertWarmRows({ count: 20 });
+  });
+  after(cleanup);
+
+  it('does not evict when row count equals cap', async () => {
+    const result = await manager.sleep(AGENT);
+
+    assert.equal(result.capacity_evicted, undefined);
+    assert.equal(await warmCount(), 20);
+  });
+});
+
+// ─── 4. Over cap — correct count and lowest-importance rows evicted ──────────
+
+describe('memory budgeting — over cap', () => {
+  const manager = makeManager({ warmTierMaxPerAgent: 20 });
+
+  // 30 rows with importance 0.1, 0.13, 0.17, … spread evenly through (0, 1]
+  const importances = Array.from({ length: 30 }, (_, i) =>
+    parseFloat(((i + 1) / 10).toFixed(2)));
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    await insertWarmRows({ count: 30, importances });
+  });
+  after(cleanup);
+
+  it('evicts exactly 10 rows and they are the 10 lowest-importance', async () => {
+    const result = await manager.sleep(AGENT);
+
+    // Exactly 10 capacity-evicted rows
+    assert.equal(result.capacity_evicted, 10);
+    assert.equal(await warmCount(), 20, 'exactly cap rows remain in warm');
+
+    // The 10 evicted rows must be in cold_tier
+    assert.equal(await coldCount(), 10);
+
+    // The surviving warm rows must be the 20 highest-importance
+    const { rows: surviving } = await pool.query<{ importance: number }>(
+      `SELECT importance FROM warm_tier WHERE agent_id = $1 ORDER BY importance ASC`,
+      [AGENT],
+    );
+    const lowestSurviving = surviving[0]!.importance;
+    const expectedCutoff = importances.sort((a, b) => a - b)[10]!; // 11th lowest
+    assert.ok(lowestSurviving >= expectedCutoff - 0.001,
+      `lowest surviving importance ${lowestSurviving} should be >= ${expectedCutoff}`);
+  });
+
+  it('evicted rows appear in cold_tier with correct namespace', async () => {
+    // cold_tier was populated by the previous test run — re-check namespace
+    const { rows } = await pool.query<{ namespace: string }>(
+      `SELECT DISTINCT namespace FROM cold_tier WHERE agent_id = $1`,
+      [AGENT],
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!.namespace, 'default');
+  });
+});
+
+// ─── 5. Capacity eviction respects namespace (cross-namespace) ───────────────
+
+describe('memory budgeting — cross-namespace cap', () => {
+  const manager = makeManager({ warmTierMaxPerAgent: 20 });
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    // 15 rows in ns 'a', 20 rows in ns 'b' — 35 total, cap=20, evict 15
+    await insertWarmRows({ count: 15, namespace: 'a' });
+    await insertWarmRows({ count: 20, namespace: 'b' });
+  });
+  after(cleanup);
+
+  it('evicts by importance regardless of namespace until total equals cap', async () => {
+    const result = await manager.sleep(AGENT);
+
+    assert.equal(result.capacity_evicted, 15);
+    assert.equal(await warmCount(), 20, 'total across all namespaces equals cap');
+    assert.equal(await coldCount(), 15, '15 rows in cold_tier');
+  });
+});
+
+// ─── 6. Interaction with threshold eviction ───────────────────────────────────
+
+describe('memory budgeting — threshold + capacity interaction', () => {
+  // evictionThreshold=0.3 evicts rows with importance < 0.3 (2 rows: 0.1 and 0.2)
+  // cap=10 means after threshold pass leaves 13, capacity evicts 3 more
+  const manager = makeManager({ warmTierMaxPerAgent: 10, evictionThreshold: 0.3 });
+
+  // 15 rows: importance 0.1, 0.2, 0.3, 0.4, … 1.5 (step 0.1)
+  const importances = Array.from({ length: 15 }, (_, i) =>
+    parseFloat(((i + 1) * 0.1).toFixed(1)));
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    await insertWarmRows({ count: 15, importances });
+  });
+  after(cleanup);
+
+  it('threshold removes sub-0.3 rows, then capacity removes the next lowest until exactly 10 remain', async () => {
+    const result = await manager.sleep(AGENT);
+
+    // 2 threshold-evicted (0.1, 0.2) + 3 capacity-evicted (0.3, 0.4, 0.5) = 5 total evicted
+    assert.equal(result.phase2_evicted, 2, 'threshold should remove 2 rows');
+    assert.equal(result.capacity_evicted, 3, 'capacity should remove 3 more');
+    assert.equal(await warmCount(), 10, 'exactly 10 remain');
+    assert.equal(await coldCount(), 5, '5 total in cold_tier');
+  });
+});
+
+// ─── 7. Graduated rows are still evictable ───────────────────────────────────
+
+describe('memory budgeting — graduated rows are not exempt from cap', () => {
+  const manager = makeManager({ warmTierMaxPerAgent: 5 });
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    // 9 normal rows with importance 0.5..0.9
+    await insertWarmRows({
+      count: 9,
+      importances: [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9],
+    });
+    // 1 graduated row with very low importance — should be evicted despite graduation
+    await pool.query(
+      `INSERT INTO warm_tier (agent_id, content, source_hot_ids, metadata, importance, graduated, namespace)
+       VALUES ($1, 'graduated but low importance', '{}', '{}', 0.1, true, 'default')`,
+      [AGENT],
+    );
+  });
+  after(cleanup);
+
+  it('evicts the graduated low-importance row because cap is a hard limit', async () => {
+    const result = await manager.sleep(AGENT);
+
+    // 10 rows total, cap=5, evict 5 (the 5 lowest: 0.1-graduated, 0.5, 0.55, 0.6, 0.65)
+    assert.equal(result.capacity_evicted, 5);
+    assert.equal(await warmCount(), 5);
+
+    // Specifically confirm the graduated row is gone from warm_tier
+    const { rows } = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM warm_tier WHERE agent_id = $1 AND graduated = true`,
+      [AGENT],
+    );
+    assert.equal(parseInt(rows[0]!.count, 10), 0, 'graduated row must have been evicted');
+
+    // And it must be in cold_tier
+    const { rows: coldRows } = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM cold_tier
+       WHERE agent_id = $1 AND content = 'graduated but low importance'`,
+      [AGENT],
+    );
+    assert.equal(parseInt(coldRows[0]!.count, 10), 1, 'graduated row must be in cold_tier');
+  });
+});


### PR DESCRIPTION
## Summary

Adds memory budgeting per the ROADMAP Phase 2 milestone: "Hard limits on warm-tier size per agent with intelligent eviction. When an agent reaches capacity, the lowest-value memories are archived, not the oldest."

**Opt-in** via \`WARM_TIER_MAX_PER_AGENT\` env var. Default (unset or 0) = no cap, existing deployments unaffected.

## Design

- **Cap is per-agent, cross-namespace.** Per-namespace caps are a future enhancement.
- **Value = importance.** Sleep cycle Phase 1 already computes importance as a weighted blend (recency, frequency, centrality, reflection, stability). Reusing it avoids duplicate scoring.
- **Graduated memories are NOT exempt.** Cap is a hard limit; graduation affects retrieval scoring, not budgeting. Documented inline.
- **Runs as Phase 2b in the sleep cycle**, immediately after threshold-based eviction (Phase 2). Kept separate from Phase 2 because the two have different invariants — threshold is "absolute below X", capacity is "relative rank bottom N" — and the log events / result fields are independently meaningful.
- **Target state: count exactly equals cap.** Simple invariant.

## No schema migration

The existing \`warm_tier_importance_idx (agent_id, importance DESC)\` already supports the bottom-N-by-importance query efficiently.

## Changes

- \`src/sleep-cycle.ts\` — new \`phaseCapacityEviction\` method, called after \`phaseTriage\`. Uses the same CTE pattern as threshold eviction (\`WITH candidates / moved / deleted\`), preserving namespace on cold rows.
- \`src/types.ts\` — \`SleepCycleConfig.warmTierMaxPerAgent?: number\`; \`SleepCycleResult.capacity_evicted?: number\` (optional, set only when cap configured).
- \`src/server.ts\` — parse \`WARM_TIER_MAX_PER_AGENT\` env var.
- \`.env.example\` — doc with opt-in + lowest-importance-first semantics.

## Tests (\`tests/memory-budgeting.test.ts\`, 307 lines, 7 cases)

1. Cap disabled (default) → no evictions.
2. Below cap → no evictions.
3. Exactly at cap → no evictions.
4. Over cap → evicts exactly (count - cap) rows, bottom-importance first, with namespace preserved in cold_tier.
5. Cross-namespace cap — per-agent applies across all namespaces.
6. Threshold + capacity interaction — both passes run, counts sum correctly.
7. Graduated row gets capacity-evicted when it is lowest-importance.

All tests use explicit timestamps — no sleeps.

## Test plan

- [ ] CI \`type-check\`, \`lint\`, \`build\` pass
- [ ] CI \`test-integration\` runs the new budgeting suite
- [ ] Existing sleep cycle tests still pass (behavior unchanged when \`warmTierMaxPerAgent\` is unset/0)

## Out of scope

- Per-namespace caps — simpler per-agent cap first per ROADMAP wording.
- Dynamic cap adjustment based on memory health — belongs in Sprint F adaptive scheduling.
- Hot_tier caps — hot_tier drains via consolidation; only warm_tier needs budgeting.