### PR TITLE
feat: adaptive sleep advisory — memory-health-driven scheduling hints (Sprint F)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,35 @@ SLEEP_CYCLE_INCLUDE_REFLECTION=true
 # Existing deployments are unaffected when left unset.
 # WARM_TIER_MAX_PER_AGENT=1000
 
+# ─── Sleep Advisory (Adaptive Scheduling) ────────────────────────────────────
+#
+# Advisory only — MemForge has no built-in scheduler by design. These thresholds
+# control the recommendation returned by GET /memory/:agentId/sleep/advisory.
+# External orchestrators (cron jobs, control planes, dashboards) read the result
+# and decide whether to call POST /memory/:agentId/sleep.
+#
+# hot_backlog signal: urgency level when unconsolidated hot-tier row count exceeds:
+# SLEEP_ADVISORY_HOT_BACKLOG_LOW=25
+# SLEEP_ADVISORY_HOT_BACKLOG_MEDIUM=100
+# SLEEP_ADVISORY_HOT_BACKLOG_HIGH=500
+#
+# contradiction_rate signal: urgency 'high' when fraction of recent reflections
+# containing contradictions exceeds this value (0–1):
+# SLEEP_ADVISORY_CONTRADICTION_HIGH=0.20
+#
+# revision_debt signal: urgency 'medium' when warm-tier rows with confidence < 0.4
+# exceeds this count:
+# SLEEP_ADVISORY_REVISION_DEBT_MEDIUM=50
+#
+# time_since_last_sleep signal: urgency 'medium' when hours since last sleep cycle
+# exceeds this value (and the agent has activity):
+# SLEEP_ADVISORY_MAX_AGE_HOURS=24
+#
+# stability ceiling: if the fraction of graduated warm-tier rows exceeds this
+# value, the overall urgency is clamped to 'low' — frequent sleeps are wasted
+# effort on a stable knowledge base:
+# SLEEP_ADVISORY_STABILITY_CEILING=0.80
+
 # ─── Temporal Intelligence ───────────────────────────────────────────────────
 
 # Temporal decay rate per hour for query ranking (default: 0 = no decay)

--- a/python/memforge/client.py
+++ b/python/memforge/client.py
@@ -353,6 +353,12 @@ class MemForgeClient:
         """Run shared pool maintenance cycle."""
         return await self._post(f"/pool/{pool_id}/sleep")
 
+    # ── Sleep Advisory ────────────────────────────────────────────────────
+
+    async def sleep_advisory(self, agent_id: str) -> dict[str, Any]:
+        """Get adaptive sleep-cycle recommendation. Advisory only — callers decide whether to act."""
+        return await self._get(f"/memory/{agent_id}/sleep/advisory")
+
     # ── System ───────────────────────────────────────────────────────────
 
     async def health(self) -> dict[str, Any]:

--- a/python/memforge/resilient.py
+++ b/python/memforge/resilient.py
@@ -180,6 +180,13 @@ class ResilientMemForgeClient:
             self._handle(e)
             return None
 
+    async def sleep_advisory(self, agent_id: str) -> dict[str, Any] | None:
+        try:
+            return await self._client.sleep_advisory(agent_id)
+        except Exception as e:
+            self._handle(e)
+            return None
+
     async def health(self) -> dict[str, Any] | None:
         try:
             return await self._client.health()

--- a/src/app.ts
+++ b/src/app.ts
@@ -705,6 +705,26 @@ export function createApp(deps: AppDependencies): express.Express {
   });
 
   /**
+   * GET /memory/:agentId/sleep/advisory
+   *
+   * Returns a structured sleep-cycle recommendation for external orchestrators.
+   * Advisory only — MemForge has no built-in scheduler.
+   */
+  app.get('/memory/:agentId/sleep/advisory', requireScope('memforge:read'), async (req: Request, res: Response) => {
+    try {
+      const advisory = await manager.sleepAdvisory(getAgentId(req));
+      ok(res, advisory);
+    } catch (err) {
+      const e = err as Error;
+      if (e instanceof TypeError) {
+        fail(res, 400, e.message);
+      } else {
+        fail(res, 500, e.message);
+      }
+    }
+  });
+
+  /**
    * GET /memory/:agentId/health
    */
   app.get('/memory/:agentId/health', requireScope('memforge:read'), async (req: Request, res: Response) => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -34,6 +34,7 @@ import type {
   HealthStatus,
   ColdTierSearchResult,
   RestoreColdTierResult,
+  SleepAdvisory,
 } from './types.js';
 
 // ─── Config ──────────────────────────────────────────────────────────────────
@@ -258,6 +259,13 @@ export class MemForgeClient {
     return this.post<RestoreColdTierResult>(`/memory/${enc(agentId)}/restore`, body);
   }
 
+  // ─── Sleep Advisory ──────────────────────────────────────────────────
+
+  /** Get adaptive sleep-cycle recommendation. Advisory only — callers decide whether to act. */
+  async sleepAdvisory(agentId: string): Promise<SleepAdvisory> {
+    return this.get<SleepAdvisory>(`/memory/${enc(agentId)}/sleep/advisory`);
+  }
+
   // ─── System ─────────────────────────────────────────────────────────────
 
   /** Health check. */
@@ -419,6 +427,10 @@ export class ResilientMemForgeClient {
 
   async restoreColdTier(agentId: string, coldId: number | bigint | string, opts: Parameters<MemForgeClient['restoreColdTier']>[2] = {}): Promise<RestoreColdTierResult | null> {
     return this.safe('restoreColdTier', () => this.client.restoreColdTier(agentId, coldId, opts), null);
+  }
+
+  async sleepAdvisory(agentId: string): Promise<SleepAdvisory | null> {
+    return this.safe('sleepAdvisory', () => this.client.sleepAdvisory(agentId), null);
   }
 
   async health(): Promise<HealthStatus | null> {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -282,6 +282,17 @@ const TOOLS: MCPToolDefinition[] = [
       required: ['agent_id', 'cold_id'],
     },
   },
+  {
+    name: 'memforge_sleep_advisory',
+    description: 'Get an adaptive sleep-cycle recommendation. Advisory only — MemForge has no built-in scheduler. Callers (cron jobs, control planes) read the urgency and reason and decide whether to call memforge_sleep.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agent_id: { type: 'string', description: 'Agent/session identifier' },
+      },
+      required: ['agent_id'],
+    },
+  },
 ];
 
 // ─── Input Validation ────────────────────────────────────────────────────────
@@ -416,6 +427,9 @@ async function executeTool(client: MemForgeClient, name: string, args: Record<st
       return client.restoreColdTier(agentId, args['cold_id'] as string, {
         namespace: args['namespace'] as string | undefined,
       });
+
+    case 'memforge_sleep_advisory':
+      return client.sleepAdvisory(agentId);
 
     default:
       throw new Error(`Unknown tool: ${name}`);

--- a/src/memory-manager.ts
+++ b/src/memory-manager.ts
@@ -53,6 +53,10 @@ import type {
   ColdTierSearchOptions,
   ColdTierSearchResult,
   RestoreColdTierResult,
+  SleepAdvisory,
+  SleepAdvisorySignal,
+  SleepAdvisoryThresholds,
+  SleepUrgency,
 } from './types.js';
 const DEFAULT_NAMESPACE = 'default';
 
@@ -64,6 +68,24 @@ function resolveNamespace(ns: string | undefined): string {
     throw new TypeError(`Invalid namespace '${ns}': ${result.error.issues[0]?.message ?? 'validation failed'}`);
   }
   return result.data;
+}
+
+const SLEEP_ADVISORY_DEFAULTS: SleepAdvisoryThresholds = {
+  hotBacklogLow: 25,
+  hotBacklogMedium: 100,
+  hotBacklogHigh: 500,
+  contradictionHigh: 0.20,
+  revisionDebtMedium: 50,
+  maxAgeHours: 24,
+  stabilityCeiling: 0.80,
+};
+
+/** Map a numeric value against a set of thresholds to an urgency level. */
+function toUrgency(value: number, low: number, medium: number, high: number): SleepUrgency {
+  if (value > high) return 'high';
+  if (value > medium) return 'medium';
+  if (value > low) return 'low';
+  return 'none';
 }
 
 const DEFAULTS: MemForgeConfig = {
@@ -2879,6 +2901,206 @@ Guidelines:
     return {
       rows: dataResult.rows,
       total: parseInt(countResult.rows[0]!.total, 10),
+    };
+  }
+
+  // ─── Sleep Advisory (Adaptive Scheduling) ────────────────────────────────
+
+  /**
+   * Returns a structured sleep-cycle recommendation for external orchestrators.
+   *
+   * MemForge has no built-in scheduler — this is purely advisory. Callers (cron
+   * jobs, control planes, dashboards) read the result and decide whether to call
+   * POST /memory/:id/sleep.
+   */
+  async sleepAdvisory(agentId: string): Promise<SleepAdvisory> {
+    this.assertAgentId(agentId);
+
+    const t: SleepAdvisoryThresholds = { ...SLEEP_ADVISORY_DEFAULTS, ...this.config.sleepAdvisoryThresholds };
+
+    // ── Gather raw data in parallel ──────────────────────────────────────
+    const [hotRow, warmRow, agentRow, revisionDebtRow, reflectionRow, activityRow] = await Promise.all([
+      this.pool.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM hot_tier WHERE agent_id = $1`,
+        [agentId],
+      ),
+      this.pool.query<{ count: string; graduated_count: string }>(
+        `SELECT count(*)::text AS count,
+                count(*) FILTER (WHERE graduated)::text AS graduated_count
+         FROM warm_tier WHERE agent_id = $1`,
+        [agentId],
+      ),
+      this.pool.query<{ last_sleep_cycle: Date | null }>(
+        `SELECT last_sleep_cycle FROM agents WHERE id = $1`,
+        [agentId],
+      ),
+      this.pool.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM warm_tier WHERE agent_id = $1 AND confidence < 0.4`,
+        [agentId],
+      ),
+      // Contradiction rate: reflections in the last 30 days or since last sleep
+      // (window is used for both numerator and denominator).
+      this.pool.query<{ total: string; with_contradictions: string }>(
+        `SELECT count(*)::text AS total,
+                count(*) FILTER (WHERE array_length(contradictions, 1) > 0)::text AS with_contradictions
+         FROM reflections
+         WHERE agent_id = $1
+           AND created_at > now() - interval '30 days'`,
+        [agentId],
+      ),
+      // Check whether any hot or warm activity has occurred since last sleep
+      // (used by the time_since_last_sleep signal to avoid pinging on empty agents).
+      this.pool.query<{ has_activity: boolean }>(
+        `SELECT (
+           EXISTS (SELECT 1 FROM hot_tier  WHERE agent_id = $1) OR
+           EXISTS (SELECT 1 FROM warm_tier WHERE agent_id = $1)
+         ) AS has_activity`,
+        [agentId],
+      ),
+    ]);
+
+    const hotCount   = parseInt(hotRow.rows[0]?.count ?? '0', 10);
+    const warmCount  = parseInt(warmRow.rows[0]?.count ?? '0', 10);
+    const gradCount  = parseInt(warmRow.rows[0]?.graduated_count ?? '0', 10);
+    const lastSleep  = agentRow.rows[0]?.last_sleep_cycle ?? null;
+    const debtCount  = parseInt(revisionDebtRow.rows[0]?.count ?? '0', 10);
+    const reflTotal  = parseInt(reflectionRow.rows[0]?.total ?? '0', 10);
+    const reflWithContradictions = parseInt(reflectionRow.rows[0]?.with_contradictions ?? '0', 10);
+    const hasActivity = activityRow.rows[0]?.has_activity ?? false;
+
+    const nowMs = Date.now();
+    const timeSinceLastSleepMs = lastSleep ? nowMs - lastSleep.getTime() : null;
+
+    const signals: SleepAdvisorySignal[] = [];
+
+    // ── Signal 1: hot_backlog ────────────────────────────────────────────
+    // Unconsolidated hot rows are raw, un-embedded, non-searchable.
+    // Draining them is the primary purpose of a sleep cycle.
+    const hotUrgency = toUrgency(hotCount, t.hotBacklogLow, t.hotBacklogMedium, t.hotBacklogHigh);
+    signals.push({
+      name: 'hot_backlog',
+      value: hotCount,
+      threshold: hotUrgency === 'high' ? t.hotBacklogHigh
+               : hotUrgency === 'medium' ? t.hotBacklogMedium
+               : hotUrgency === 'low' ? t.hotBacklogLow
+               : t.hotBacklogLow,
+      urgency: hotUrgency,
+      description: `${hotCount} hot-tier rows awaiting consolidation`,
+    });
+
+    // ── Signal 2: contradiction_rate ─────────────────────────────────────
+    // Rising contradictions signal knowledge drift — the sleep cycle's Phase 2.5
+    // conflict resolution handles this.
+    const contradictionRate = reflTotal > 0 ? reflWithContradictions / reflTotal : 0;
+    const contradictionUrgency: SleepUrgency =
+      contradictionRate > t.contradictionHigh ? 'high'
+      : contradictionRate > 0.10 ? 'medium'
+      : contradictionRate > 0.05 ? 'low'
+      : 'none';
+    signals.push({
+      name: 'contradiction_rate',
+      value: contradictionRate,
+      threshold: contradictionUrgency === 'high' ? t.contradictionHigh
+               : contradictionUrgency === 'medium' ? 0.10
+               : contradictionUrgency === 'low' ? 0.05
+               : t.contradictionHigh,
+      urgency: contradictionUrgency,
+      description: reflTotal === 0
+        ? 'no reflections in the past 30 days'
+        : `${(contradictionRate * 100).toFixed(0)}% of recent reflections contain contradictions`,
+    });
+
+    // ── Signal 3: revision_debt ──────────────────────────────────────────
+    // Low-confidence rows need LLM-driven revision in Phase 3 of the sleep cycle.
+    const debtUrgency: SleepUrgency =
+      debtCount > t.revisionDebtMedium ? 'medium'
+      : debtCount > 20 ? 'low'
+      : 'none';
+    signals.push({
+      name: 'revision_debt',
+      value: debtCount,
+      threshold: debtUrgency === 'medium' ? t.revisionDebtMedium : 20,
+      urgency: debtUrgency,
+      description: `${debtCount} warm-tier rows with confidence < 0.4`,
+    });
+
+    // ── Signal 4: time_since_last_sleep ──────────────────────────────────
+    // Even a stable knowledge base benefits from periodic maintenance when
+    // new data has arrived since the last cycle.
+    const maxAgeMs = t.maxAgeHours * 3_600_000;
+    let timeUrgency: SleepUrgency = 'none';
+    if (timeSinceLastSleepMs !== null && hasActivity) {
+      if (timeSinceLastSleepMs > maxAgeMs) {
+        timeUrgency = 'medium';
+      } else if (timeSinceLastSleepMs > maxAgeMs / 2) {
+        timeUrgency = 'low';
+      }
+    } else if (timeSinceLastSleepMs === null && hasActivity) {
+      // Agent has never slept but has data — treat as overdue.
+      timeUrgency = 'low';
+    }
+    signals.push({
+      name: 'time_since_last_sleep',
+      value: timeSinceLastSleepMs !== null ? timeSinceLastSleepMs / 3_600_000 : 0,
+      threshold: t.maxAgeHours,
+      urgency: timeUrgency,
+      description: lastSleep
+        ? `last sleep was ${(timeSinceLastSleepMs! / 3_600_000).toFixed(1)} h ago`
+        : 'agent has never completed a sleep cycle',
+    });
+
+    // ── Signal 5: stability (inverse — clamps overall urgency down) ──────
+    // A highly-graduated agent has a well-consolidated knowledge base;
+    // running frequent sleep cycles is wasted LLM spend.
+    const stabilityRatio = warmCount > 0 ? gradCount / warmCount : 0;
+    const stabilityHit = stabilityRatio > t.stabilityCeiling;
+    signals.push({
+      name: 'stability',
+      value: stabilityRatio,
+      threshold: t.stabilityCeiling,
+      // The stability signal itself carries no positive urgency — it only caps others.
+      urgency: 'none',
+      description: `${(stabilityRatio * 100).toFixed(0)}% of warm-tier rows graduated${stabilityHit ? ' — stability ceiling active' : ''}`,
+    });
+
+    // ── Compute overall urgency ──────────────────────────────────────────
+    const URGENCY_ORDER: SleepUrgency[] = ['none', 'low', 'medium', 'high'];
+    const maxIndex = signals
+      .filter((s) => s.name !== 'stability')
+      .reduce((best, s) => Math.max(best, URGENCY_ORDER.indexOf(s.urgency)), 0);
+
+    let overallUrgency = URGENCY_ORDER[maxIndex]!;
+
+    // If stability ceiling is hit, clamp urgency to 'low' at most.
+    if (stabilityHit && URGENCY_ORDER.indexOf(overallUrgency) > URGENCY_ORDER.indexOf('low')) {
+      overallUrgency = 'low';
+    }
+
+    // ── Build reason string ──────────────────────────────────────────────
+    const contributing = signals
+      .filter((s) => s.name !== 'stability' && s.urgency !== 'none')
+      .sort((a, b) => URGENCY_ORDER.indexOf(b.urgency) - URGENCY_ORDER.indexOf(a.urgency))
+      .slice(0, 2);
+
+    let reason: string;
+    if (overallUrgency === 'none') {
+      reason = 'no sleep signals active';
+    } else {
+      const parts = contributing.map((s) => s.description);
+      const suffix = ` — sleep ${overallUrgency === 'high' || overallUrgency === 'medium' ? 'recommended' : 'optional'}`;
+      reason = (parts.join('; ') + suffix).slice(0, 120);
+    }
+
+    return {
+      agent_id: agentId,
+      recommended: overallUrgency === 'medium' || overallUrgency === 'high',
+      urgency: overallUrgency,
+      reason,
+      signals,
+      last_sleep_at: lastSleep,
+      hot_tier_count: hotCount,
+      warm_tier_count: warmCount,
+      time_since_last_sleep_ms: timeSinceLastSleepMs,
     };
   }
 

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -494,6 +494,59 @@ export function buildOpenApiSpec(port: number): Record<string, unknown> {
           },
         },
       },
+      '/memory/{agentId}/sleep/advisory': {
+        get: {
+          summary: 'Get adaptive sleep advisory — advisory only, MemForge has no built-in scheduler',
+          tags: ['Memory'],
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            { name: 'agentId', in: 'path', required: true, schema: { type: 'string' } },
+          ],
+          responses: {
+            '200': {
+              description: 'Sleep advisory with urgency, reason, and individual signals. Callers decide whether to act.',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      ok: { type: 'boolean', example: true },
+                      data: {
+                        type: 'object',
+                        properties: {
+                          agent_id: { type: 'string' },
+                          recommended: { type: 'boolean', description: 'true when urgency is medium or high' },
+                          urgency: { type: 'string', enum: ['none', 'low', 'medium', 'high'] },
+                          reason: { type: 'string', description: 'One-line summary ≤120 chars' },
+                          signals: {
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                              properties: {
+                                name: { type: 'string' },
+                                value: { type: 'number' },
+                                threshold: { type: 'number' },
+                                urgency: { type: 'string', enum: ['none', 'low', 'medium', 'high'] },
+                                description: { type: 'string' },
+                              },
+                            },
+                          },
+                          last_sleep_at: { type: 'string', format: 'date-time', nullable: true },
+                          hot_tier_count: { type: 'integer' },
+                          warm_tier_count: { type: 'integer' },
+                          time_since_last_sleep_ms: { type: 'integer', nullable: true },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            '400': { '$ref': '#/components/responses/BadRequest' },
+            '500': { '$ref': '#/components/responses/InternalError' },
+          },
+        },
+      },
       '/admin/cache/stats': {
         get: {
           summary: 'Cache statistics (admin)',

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,6 +76,15 @@ const manager = new MemoryManager({
     },
   },
   auditChain,
+  sleepAdvisoryThresholds: {
+    ...(process.env['SLEEP_ADVISORY_HOT_BACKLOG_LOW']      ? { hotBacklogLow:      parseInt(process.env['SLEEP_ADVISORY_HOT_BACKLOG_LOW'], 10) }      : {}),
+    ...(process.env['SLEEP_ADVISORY_HOT_BACKLOG_MEDIUM']   ? { hotBacklogMedium:   parseInt(process.env['SLEEP_ADVISORY_HOT_BACKLOG_MEDIUM'], 10) }   : {}),
+    ...(process.env['SLEEP_ADVISORY_HOT_BACKLOG_HIGH']     ? { hotBacklogHigh:     parseInt(process.env['SLEEP_ADVISORY_HOT_BACKLOG_HIGH'], 10) }     : {}),
+    ...(process.env['SLEEP_ADVISORY_CONTRADICTION_HIGH']   ? { contradictionHigh:  parseFloat(process.env['SLEEP_ADVISORY_CONTRADICTION_HIGH']) }     : {}),
+    ...(process.env['SLEEP_ADVISORY_REVISION_DEBT_MEDIUM'] ? { revisionDebtMedium: parseInt(process.env['SLEEP_ADVISORY_REVISION_DEBT_MEDIUM'], 10) } : {}),
+    ...(process.env['SLEEP_ADVISORY_MAX_AGE_HOURS']        ? { maxAgeHours:        parseFloat(process.env['SLEEP_ADVISORY_MAX_AGE_HOURS']) }          : {}),
+    ...(process.env['SLEEP_ADVISORY_STABILITY_CEILING']    ? { stabilityCeiling:   parseFloat(process.env['SLEEP_ADVISORY_STABILITY_CEILING']) }      : {}),
+  },
 });
 
 // ─── Webhooks ────────────────────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -455,6 +455,8 @@ export interface MemForgeConfig {
   sleepCycle: SleepCycleConfig;
   /** Audit chain instance for recording mutations (optional) */
   auditChain?: AuditChain | null;
+  /** Thresholds for the sleepAdvisory() recommendation engine (optional — defaults apply) */
+  sleepAdvisoryThresholds?: Partial<SleepAdvisoryThresholds>;
 }
 
 /** Agent-provided memory hints for active ingest participation */
@@ -473,6 +475,43 @@ export interface MemoryHints {
   type?: 'fact' | 'event' | 'decision' | 'preference' | 'correction' | 'error';
 }
 
+
+// ─── Sleep Advisory (Adaptive Scheduling) ────────────────────────────────────
+
+export type SleepUrgency = 'none' | 'low' | 'medium' | 'high';
+
+export interface SleepAdvisorySignal {
+  name: string;
+  value: number;
+  threshold: number;
+  urgency: SleepUrgency;
+  description: string;
+}
+
+export interface SleepAdvisory {
+  agent_id: string;
+  recommended: boolean;
+  urgency: SleepUrgency;
+  reason: string;
+  signals: SleepAdvisorySignal[];
+  last_sleep_at: Date | null;
+  hot_tier_count: number;
+  warm_tier_count: number;
+  time_since_last_sleep_ms: number | null;
+}
+
+/** Thresholds for the sleep advisory signals. Overridable via config or env vars. */
+export interface SleepAdvisoryThresholds {
+  hotBacklogLow: number;
+  hotBacklogMedium: number;
+  hotBacklogHigh: number;
+  contradictionHigh: number;
+  revisionDebtMedium: number;
+  maxAgeHours: number;
+  stabilityCeiling: number;
+}
+
+// ─── (continued) ─────────────────────────────────────────────────────────────
 
 /** PostgreSQL query parameter — union of types accepted by the `pg` driver's parameterized queries. */
 export type SqlParam = string | number | bigint | boolean | Date | null | string[] | number[] | bigint[];

--- a/tests/sleep-advisory.test.ts
+++ b/tests/sleep-advisory.test.ts
@@ -1,0 +1,281 @@
+// MemForge — Sleep Advisory Tests (Sprint F, Phase 2)
+//
+// Tests the advisory sleep-scheduling recommendation engine.
+// All tests use explicit data insertion and timestamps — no sleeps, no fixed waits.
+//
+// Run: node --import tsx/esm --test tests/sleep-advisory.test.ts
+//
+// WARNING: Requires DATABASE_URL pointing to a test database with schema applied.
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { Pool } from 'pg';
+
+const { MemoryManager } = await import('../src/memory-manager.js');
+const { NoOpEmbeddingProvider } = await import('../src/embedding.js');
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+if (!DATABASE_URL) {
+  console.error('[test] DATABASE_URL is required — set it to a test database');
+  process.exit(1);
+}
+
+const AGENT = 'test-advisory-agent';
+
+const pool = new Pool({ connectionString: DATABASE_URL });
+
+async function ensureAgent(): Promise<void> {
+  await pool.query(
+    `INSERT INTO agents (id, metadata) VALUES ($1, '{}') ON CONFLICT (id) DO NOTHING`,
+    [AGENT],
+  );
+}
+
+async function cleanup(): Promise<void> {
+  await pool.query(`DELETE FROM reflections WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM warm_tier_entities WHERE warm_tier_id IN (SELECT id FROM warm_tier WHERE agent_id = $1)`, [AGENT]);
+  await pool.query(`DELETE FROM cold_tier WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM warm_tier WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM hot_tier WHERE agent_id = $1`, [AGENT]);
+  await pool.query(`DELETE FROM agents WHERE id = $1`, [AGENT]);
+}
+
+async function insertHotRows(count: number): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await pool.query(
+      `INSERT INTO hot_tier (agent_id, content, metadata, namespace)
+       VALUES ($1, $2, '{}', 'default')`,
+      [AGENT, `hot row ${i}`],
+    );
+  }
+}
+
+async function insertWarmRows(opts: { count: number; confidence?: number; graduated?: boolean }): Promise<void> {
+  const confidence = opts.confidence ?? 0.8;
+  const graduated = opts.graduated ?? false;
+  for (let i = 0; i < opts.count; i++) {
+    await pool.query(
+      `INSERT INTO warm_tier (agent_id, content, source_hot_ids, metadata, confidence, graduated, namespace)
+       VALUES ($1, $2, '{}', '{}', $3, $4, 'default')`,
+      [AGENT, `warm row ${i}`, confidence, graduated],
+    );
+  }
+}
+
+async function insertReflections(total: number, withContradictions: number): Promise<void> {
+  const now = new Date();
+  for (let i = 0; i < total; i++) {
+    const contradictions = i < withContradictions ? ['A contradicts B'] : [];
+    await pool.query(
+      `INSERT INTO reflections (agent_id, content, key_insights, contradictions, source_warm_ids,
+                                trigger_type, reflection_level, source_reflection_ids, metadata, namespace, created_at)
+       VALUES ($1, $2, '{}', $3, '{}', 'manual', 1, '{}', '{}', 'default', $4)`,
+      [AGENT, `reflection ${i}`, JSON.stringify(contradictions), now],
+    );
+  }
+}
+
+async function setLastSleep(hoursAgo: number): Promise<void> {
+  const ts = new Date(Date.now() - hoursAgo * 3_600_000);
+  await pool.query(`UPDATE agents SET last_sleep_cycle = $1 WHERE id = $2`, [ts, AGENT]);
+}
+
+function makeManager(overrides: Record<string, unknown> = {}): InstanceType<typeof MemoryManager> {
+  return new MemoryManager({
+    databaseUrl: DATABASE_URL!,
+    autoRegisterAgents: false,
+    embeddingProvider: new NoOpEmbeddingProvider(),
+    ...overrides,
+  });
+}
+
+// ─── 1. No activity → urgency 'none' ─────────────────────────────────────────
+
+describe('sleep advisory — no activity', () => {
+  const manager = makeManager();
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+  });
+  after(cleanup);
+
+  it('returns urgency=none and recommended=false when agent has no data', async () => {
+    const advisory = await manager.sleepAdvisory(AGENT);
+
+    assert.equal(advisory.urgency, 'none');
+    assert.equal(advisory.recommended, false);
+    assert.equal(advisory.agent_id, AGENT);
+    assert.equal(advisory.hot_tier_count, 0);
+    assert.equal(advisory.warm_tier_count, 0);
+  });
+});
+
+// ─── 2. Hot backlog → high urgency ───────────────────────────────────────────
+
+describe('sleep advisory — hot backlog triggers high urgency', () => {
+  const manager = makeManager();
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    await insertHotRows(600);
+  });
+  after(cleanup);
+
+  it('returns urgency=high and the hot_backlog signal reports value=600', async () => {
+    const advisory = await manager.sleepAdvisory(AGENT);
+
+    assert.equal(advisory.urgency, 'high');
+    assert.equal(advisory.recommended, true);
+    assert.equal(advisory.hot_tier_count, 600);
+
+    const signal = advisory.signals.find((s) => s.name === 'hot_backlog');
+    assert.ok(signal, 'hot_backlog signal must be present');
+    assert.equal(signal!.value, 600);
+    assert.equal(signal!.urgency, 'high');
+  });
+});
+
+// ─── 3. Contradiction rate → high urgency ────────────────────────────────────
+
+describe('sleep advisory — contradiction rate triggers high urgency', () => {
+  const manager = makeManager();
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    // 2 of 10 reflections have contradictions → ratio 0.20 ≥ default threshold 0.20 → high
+    await insertReflections(10, 2);
+  });
+  after(cleanup);
+
+  it('returns urgency=high when contradiction rate equals the high threshold', async () => {
+    const advisory = await manager.sleepAdvisory(AGENT);
+
+    const signal = advisory.signals.find((s) => s.name === 'contradiction_rate');
+    assert.ok(signal, 'contradiction_rate signal must be present');
+    assert.ok(signal!.value >= 0.20, `expected rate ≥ 0.20, got ${signal!.value}`);
+    assert.equal(signal!.urgency, 'high');
+    assert.equal(advisory.urgency, 'high');
+  });
+});
+
+// ─── 4. Revision debt → medium urgency ───────────────────────────────────────
+
+describe('sleep advisory — revision debt triggers medium urgency', () => {
+  const manager = makeManager();
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    await insertWarmRows({ count: 60, confidence: 0.2 });
+  });
+  after(cleanup);
+
+  it('returns the revision_debt signal with value=60 and urgency=medium', async () => {
+    const advisory = await manager.sleepAdvisory(AGENT);
+
+    const signal = advisory.signals.find((s) => s.name === 'revision_debt');
+    assert.ok(signal, 'revision_debt signal must be present');
+    assert.equal(signal!.value, 60);
+    assert.equal(signal!.urgency, 'medium');
+    assert.equal(advisory.urgency, 'medium');
+  });
+});
+
+// ─── 5. Time since last sleep → medium urgency ───────────────────────────────
+
+describe('sleep advisory — time since last sleep triggers medium urgency', () => {
+  const manager = makeManager();
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    // One hot row so hasActivity=true
+    await insertHotRows(1);
+    // Set last sleep to 25 h ago (> default 24 h threshold)
+    await setLastSleep(25);
+  });
+  after(cleanup);
+
+  it('returns urgency=medium from time_since_last_sleep signal', async () => {
+    const advisory = await manager.sleepAdvisory(AGENT);
+
+    const signal = advisory.signals.find((s) => s.name === 'time_since_last_sleep');
+    assert.ok(signal, 'time_since_last_sleep signal must be present');
+    assert.ok(signal!.value > 24, `expected > 24 h, got ${signal!.value}`);
+    assert.equal(signal!.urgency, 'medium');
+    // hot_backlog has only 1 row — well below all thresholds, so time signal dominates
+    assert.ok(
+      advisory.urgency === 'medium' || advisory.urgency === 'high',
+      `expected urgency medium or high, got ${advisory.urgency}`,
+    );
+  });
+});
+
+// ─── 6. Stability ceiling clamps urgency ─────────────────────────────────────
+
+describe('sleep advisory — stability ceiling clamps urgency', () => {
+  const manager = makeManager();
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    // 100 warm rows, 85 graduated → 85% graduation > ceiling 0.80
+    await insertWarmRows({ count: 85, graduated: true });
+    await insertWarmRows({ count: 15, graduated: false });
+    // 600 hot rows would normally trigger high urgency
+    await insertHotRows(600);
+  });
+  after(cleanup);
+
+  it('caps overall urgency to low despite hot_backlog=600 when stability ceiling is active', async () => {
+    const advisory = await manager.sleepAdvisory(AGENT);
+
+    // The stability signal itself carries no positive urgency
+    const stabilitySignal = advisory.signals.find((s) => s.name === 'stability');
+    assert.ok(stabilitySignal, 'stability signal must be present');
+    assert.equal(stabilitySignal!.urgency, 'none');
+    assert.ok(stabilitySignal!.value > 0.80, `expected stability > 0.80, got ${stabilitySignal!.value}`);
+
+    // Hot backlog signal is still high internally
+    const hotSignal = advisory.signals.find((s) => s.name === 'hot_backlog');
+    assert.ok(hotSignal, 'hot_backlog signal must be present');
+    assert.equal(hotSignal!.urgency, 'high');
+
+    // But overall urgency is clamped to low
+    assert.equal(advisory.urgency, 'low', 'stability ceiling must clamp overall urgency to low');
+  });
+});
+
+// ─── 7. Custom thresholds via config ─────────────────────────────────────────
+
+describe('sleep advisory — custom thresholds override defaults', () => {
+  // Lower hotBacklogHigh to 50 so that 60 rows trigger high
+  const manager = makeManager({
+    sleepAdvisoryThresholds: { hotBacklogHigh: 50 },
+  });
+
+  before(async () => {
+    await cleanup();
+    await ensureAgent();
+    await insertHotRows(60);
+  });
+  after(cleanup);
+
+  it('returns urgency=high when hot rows exceed the custom hotBacklogHigh threshold', async () => {
+    const advisory = await manager.sleepAdvisory(AGENT);
+
+    assert.equal(advisory.urgency, 'high');
+    assert.equal(advisory.recommended, true);
+
+    const signal = advisory.signals.find((s) => s.name === 'hot_backlog');
+    assert.ok(signal, 'hot_backlog signal must be present');
+    assert.equal(signal!.value, 60);
+    assert.equal(signal!.urgency, 'high');
+    assert.equal(signal!.threshold, 50);
+  });
+});


### PR DESCRIPTION
## Summary

ROADMAP Phase 2 **adaptive sleep scheduling**. Completes Phase 2.

MemForge is intentionally designed **without a built-in scheduler** (CLAUDE.md architectural rule). This PR instead exposes a read-only advisory that external orchestrators (cron, control plane, dashboards) can use to decide when to trigger a sleep cycle.

## \`MemoryManager.sleepAdvisory(agentId)\` signals

| Signal | Source | Semantics |
|---|---|---|
| \`hot_backlog\` | \`count(hot_tier)\` | Raw, un-embedded, non-searchable events; draining is the primary sleep purpose. |
| \`contradiction_rate\` | \`reflections.contradictions\` last 30d | Rising contradictions signal knowledge drift → Phase 2.5 conflict resolution needed. |
| \`revision_debt\` | warm rows with \`confidence < 0.4\` | Low-confidence rows need Phase 3 LLM revision. |
| \`time_since_last_sleep\` | \`agents.last_sleep_cycle\` (v2.4) | Periodic maintenance when any activity has occurred. |
| \`stability\` (inverse) | \`graduated / warm_count\` | High stability → frequent sleep is wasted LLM spend; clamps overall urgency down. |

**Overall urgency** = max of the four active signals, then clamped to \`'low'\` if stability ceiling exceeded. \`recommended = urgency >= 'medium'\`.

## Thresholds (all tunable via env)

- \`SLEEP_ADVISORY_HOT_BACKLOG_LOW\` / \`MEDIUM\` / \`HIGH\` = 25 / 100 / 500
- \`SLEEP_ADVISORY_CONTRADICTION_HIGH\` = 0.20 (0.10 medium, 0.05 low are inline)
- \`SLEEP_ADVISORY_REVISION_DEBT_MEDIUM\` = 50 (20 low)
- \`SLEEP_ADVISORY_MAX_AGE_HOURS\` = 24
- \`SLEEP_ADVISORY_STABILITY_CEILING\` = 0.80

## Public surfaces

- \`GET /memory/:id/sleep/advisory\` (read-scoped)
- \`memforge_sleep_advisory\` MCP tool
- \`sleepAdvisory()\` on TS \`MemForgeClient\` + \`ResilientMemForgeClient\`
- \`sleep_advisory()\` on Python equivalents
- OpenAPI route documented with full response schema

No schema migration — all required columns already present.

## Tests (\`tests/sleep-advisory.test.ts\`, 281 lines, 7 cases)

1. No activity → \`'none'\`, recommended false.
2. 600 hot rows → \`hot_backlog\` urgency \`'high'\`.
3. 2/10 reflections w/ contradictions (ratio 0.20) → urgency \`'high'\`.
4. 60 low-confidence warm rows → \`revision_debt\` urgency \`'medium'\`.
5. \`last_sleep_cycle\` 25h ago + activity → urgency \`'medium'\`.
6. 85/100 graduated + 600 hot → stability ceiling clamps to \`'low'\`.
7. Custom \`hotBacklogHigh=50\` override → 60 hot rows → urgency \`'high'\`.

All use explicit timestamps, no sleeps.

## Test plan

- [ ] CI type-check / lint / build pass
- [ ] CI test-integration (Node 20 + 22) runs the new suite
- [ ] Existing sleep cycle + budgeting tests unaffected

## Phase 2 scorecard (closed out after this merge)

- ✅ Memory namespaces (#16) — C.1 + C.2 (PRs #100, #101)
- ✅ Cold tier search + restoration (#14) — D (PR #102)
- ✅ Memory budgeting — E (PR #103)
- ✅ Adaptive sleep scheduling — F (this PR)
- ✅ Per-agent scoring weights (#17) — shipped in v2.4 migration
- ⚠️ Multi-model revision (#13) — basic plumbing already in place (REVISION_LLM_PROVIDER); "two-pass triage" variant deferred