### PR TITLE
chore(release): v3.0.0-beta.4 — Phase 2 complete, halfvec HNSW fix (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,103 @@
 
 All notable changes to MemForge are documented here.
 
+## [3.0.0-beta.4] - 2026-04-18 — Phase 2: Long-Term Memory at Scale
+
+Completes Phase 2 of the ROADMAP. Adds domain partitioning, cold-tier
+recovery, hard memory budgets, and adaptive scheduling hints — plus the
+first release publishing via npm **Trusted Publishing (OIDC)** instead
+of a long-lived token.
+
+### Added
+
+- **Memory namespaces (#16)** — optional `namespace` argument on
+  `add` / `query` / `consolidate` / `timeline` / `stats` / `resume` /
+  `export` / `import` / `pruneColdTier`. Default namespace is
+  `'default'`, so existing callers are unaffected. Entities and
+  relationships remain agent-scoped (knowledge graph shared across
+  namespaces by design). Migration `schema/migration-v3.1.sql`
+  adds a `namespace TEXT NOT NULL DEFAULT 'default'` column to
+  eight memory tables with composite `(agent_id, namespace)` indexes.
+  Public surface covers HTTP, MCP, TypeScript SDK, Python SDK, and
+  OpenAPI. Sleep cycles are intentionally agent-wide (not
+  namespace-scoped) — the 10-phase cycle doesn't yet filter by
+  namespace, and `SleepSchema` explicitly does not accept a
+  namespace argument so the API doesn't claim behavior it can't
+  deliver.
+- **Cold tier search + restoration (#14)** —
+  `MemoryManager.searchColdTier(agentId, opts)` filters archived
+  rows by content substring, namespace, archive-timestamp range,
+  and source table with limit/offset paging.
+  `restoreColdTier(agentId, coldTierId, opts?)` copies a cold row
+  back into warm tier non-destructively (cold row preserved, warm
+  row stamped with `metadata._restored_from_cold_id` for audit).
+  New routes `GET /memory/:id/cold` and `POST /memory/:id/restore`,
+  plus MCP tools and SDK methods. No schema migration needed.
+- **Memory budgeting** — new opt-in `WARM_TIER_MAX_PER_AGENT` env
+  var enforces a per-agent hard cap on warm_tier rows. Capacity
+  eviction runs as Phase 2b of the sleep cycle (after threshold
+  eviction) and archives lowest-importance rows — not oldest —
+  until the cap is met. Uses the existing `warm_tier_importance_idx`
+  for efficient scans. Graduated memories are NOT exempt: cap is a
+  hard limit; graduation affects retrieval scoring only.
+  `SleepCycleResult.capacity_evicted` is set when a cap is
+  configured.
+- **Adaptive sleep advisory (Phase 2 adaptive scheduling)** —
+  `MemoryManager.sleepAdvisory(agentId)` returns a
+  health-metric-based scheduling recommendation over five signals:
+  hot backlog, contradiction rate, revision debt, time since last
+  sleep, and an inverse stability signal that clamps urgency
+  downward when the knowledge base is highly graduated.
+  `recommended` flips to `true` at urgency `'medium'` or `'high'`.
+  External orchestrators (cron, dashboards, control planes) call
+  this instead of scheduling blindly — MemForge stays
+  scheduler-free by design. New HTTP route
+  `GET /memory/:id/sleep/advisory`, MCP tool `memforge_sleep_advisory`,
+  and SDK methods on both TS and Python clients. Thresholds
+  configurable via `SLEEP_ADVISORY_*` env vars.
+- **Optional HNSW index template** (#95) — new
+  `schema/hnsw-indexes.example.sql` documents how operators who use
+  embeddings should pin the `warm_tier.embedding` and
+  `shared_memories.embedding` halfvec columns to their provider's
+  dimension and build HNSW indexes for fast cosine similarity.
+  Common dimensions (384, 768, 1536, 3072) listed inline.
+
+### Changed
+
+- **npm publish switched to Trusted Publishing (OIDC)** — release
+  workflow no longer requires `NODE_AUTH_TOKEN`; the
+  `id-token: write` permission is enough, and npm validates the
+  publish came from this specific repo + workflow via OIDC. No
+  long-lived token to rotate or leak. The `NPM_TOKEN` secret can
+  now be deleted from the repo (kept as fallback for beta.4 out
+  of caution).
+- **`schema/schema.sql`** no longer tries to build HNSW indexes on
+  bare-dimension halfvec columns (#95). The two failing
+  `CREATE INDEX ... USING hnsw` statements have been replaced with
+  comments pointing to `hnsw-indexes.example.sql`. Fresh installs
+  without embeddings are now silent (no `psql` ERROR lines); installs
+  with embeddings apply the example after choosing a dimension.
+  Semantic search falls back to sequential scan on unindexed halfvec
+  columns — correct but slower.
+- **Bumped `package.json` to `3.0.0-beta.4`**.
+- **Closed GitHub issues** — #10 (npm publish), #14 (cold tier
+  search + restoration), #16 (namespaces), #17 (per-agent weights
+  — previously shipped in v2.4), #18 (CORS), #35 (audit
+  immutability), #43 (global rate limiting), #46 (deployment
+  security guide), #50 (knowledge graduation). All were already
+  shipped but not yet closed on the tracker.
+
+### Known gaps documented
+
+- **#13 Multi-model revision — two-pass triage variant** — still
+  future work. The basic cheap/capable split via
+  `REVISION_LLM_PROVIDER` already works today.
+- **#41 Redis cache poisoning** — confirmed `src/cache.ts` does not
+  Zod-validate deserialised cache entries. Future security sprint.
+- **#21 Integration guides** — LangChain and CrewAI are covered;
+  AutoGen remains gap in `INTEGRATION.md`.
+- **#22 Architecture Decision Records** — still future docs work.
+
 ## [3.0.0-beta.3] - 2026-04-17 — Documentation & Schema Consolidation
 
 This release regularizes the `v3.0.0-beta.x` series. `v3.0.0-beta.1` and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ The goal is a constant set of evolving agents developed and refined over years, 
 
 ---
 
-## Where We Are Today (v3.0.0-beta.3)
+## Where We Are Today (v3.0.0-beta.4)
 
 MemForge has a production-grade foundation with CI fully green:
 
@@ -36,35 +36,31 @@ MemForge has a production-grade foundation with CI fully green:
 *Make MemForge reliable enough to trust with long-lived agents.*
 
 All Phase 1 items are implemented:
-- CI/CD pipeline with 6 jobs (Node 20+22) — all green
+- CI/CD pipeline with 8 jobs (Node 20+22) — typecheck / lint / build / security / integration / cache / load / RLS enforcement. Release workflow via npm Trusted Publishing (OIDC).
 - Mocked LLM test suite, HTTP API tests, load tests, security tests
 - Structured JSON logging with request correlation IDs (pino)
 - Connection pool hardening with health checks, timeouts, auto-scaling
-- npm package configured as `@salishforge/memforge` ([#10](https://github.com/salishforge/memforge/issues/10) — publish pending)
-
-### Remaining
-
-- **Streaming consolidation** — cursor-based processing for 10K+ event backlogs ([#11](https://github.com/salishforge/memforge/issues/11))
-- **Cold tier retention policies** — configurable cleanup ([#20](https://github.com/salishforge/memforge/issues/20))
-- **npm publish** — publish to npm registry ([#10](https://github.com/salishforge/memforge/issues/10))
+- **Streaming consolidation** — cursor-based per-transaction batches, idempotent re-run ([#11](https://github.com/salishforge/memforge/issues/11)) — ✅ DONE
+- **Cold tier retention** — opt-in `COLD_TIER_RETENTION_DAYS` with audit trail ([#20](https://github.com/salishforge/memforge/issues/20)) — ✅ DONE
+- **npm publish** — live at `@salishforge/memforge` ([#10](https://github.com/salishforge/memforge/issues/10)) — ✅ DONE
 
 ---
 
-## Phase 2: Long-Term Memory at Scale (Q3-Q4 2026)
+## Phase 2: Long-Term Memory at Scale — COMPLETE
 
 *Enable agents to accumulate months of experience without degradation.*
 
 ### Memory Lifecycle Management
 
-- **Memory namespaces** — Partition memories by domain, project, or context so agents with broad responsibilities maintain focused retrieval ([#16](https://github.com/salishforge/memforge/issues/16)) — ✅ DONE: backend in PR #100; HTTP/MCP/TypeScript SDK/OpenAPI/Python SDK surface in this PR (C.2)
+- **Memory namespaces** — Partition memories by domain, project, or context so agents with broad responsibilities maintain focused retrieval ([#16](https://github.com/salishforge/memforge/issues/16)) — ✅ DONE (PRs #100, #101)
 - **Per-agent importance tuning** — Different agents need different memory profiles. A support agent should weight recency; a research agent should weight graph centrality ([#17](https://github.com/salishforge/memforge/issues/17)) — ✅ DONE: shipped in v2.4 migration (#57) — `agents.scoring_weights` JSONB column wired into sleep cycle phase 1
-- **Cold tier search and restoration** — Query archived memories and selectively restore them when context shifts back to old topics ([#14](https://github.com/salishforge/memforge/issues/14))
+- **Cold tier search and restoration** — Query archived memories and selectively restore them when context shifts back to old topics ([#14](https://github.com/salishforge/memforge/issues/14)) — ✅ DONE (PR #102)
 
 ### Intelligent Resource Management
 
-- **Multi-model revision strategy** — Cheap local models for routine sleep cycle maintenance, capable cloud models for high-stakes revisions. Reduce costs 60-80% while maintaining quality where it matters ([#13](https://github.com/salishforge/memforge/issues/13))
-- **Adaptive sleep scheduling** — Automatically trigger sleep cycles based on memory health metrics rather than fixed schedules. If contradiction rate is rising, sleep more. If knowledge is stable, sleep less.
-- **Memory budgeting** — Hard limits on warm-tier size per agent with intelligent eviction. When an agent reaches capacity, the lowest-value memories are archived, not the oldest.
+- **Multi-model revision strategy** — Cheap local models for routine sleep cycle maintenance, capable cloud models for high-stakes revisions ([#13](https://github.com/salishforge/memforge/issues/13)) — ⚠️ PARTIAL: `REVISION_LLM_PROVIDER` env var already routes revision calls to a separate provider instance (cheap/capable split works today). The "two-pass triage" variant (cheap classifier → capable executor) remains future work on this issue.
+- **Adaptive sleep scheduling** — `sleepAdvisory(agentId)` returns a structured recommendation based on hot backlog, contradiction rate, revision debt, time since last sleep, and stability ceiling. External orchestrators (cron, control plane) consume it; MemForge stays scheduler-free by design. — ✅ DONE (PR #104)
+- **Memory budgeting** — `WARM_TIER_MAX_PER_AGENT` hard cap with lowest-importance eviction. Runs as Phase 2b of the sleep cycle after threshold eviction. — ✅ DONE (PR #103)
 
 ### Quality Metrics Dashboard
 
@@ -73,7 +69,7 @@ All Phase 1 items are implemented:
 
 ### Milestone
 
-An agent with 6+ months of accumulated memory, warm tier at 50K+ entries, demonstrably better retrieval quality than month 1.
+An agent with 6+ months of accumulated memory, warm tier at 50K+ entries, demonstrably better retrieval quality than month 1. The sleep advisory (PR #104) gives operators the scheduling signal needed to sustain this at scale; the warm-tier cap + intelligent eviction keeps retrieval focused even as raw ingest volume grows.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salishforge/memforge",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "description": "Neuroscience-inspired agent memory — sleep cycles, memory revision, knowledge graph, procedural learning, vector search, and MCP integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/schema/hnsw-indexes.example.sql
+++ b/schema/hnsw-indexes.example.sql
@@ -1,0 +1,60 @@
+-- MemForge — Optional HNSW Indexes for Semantic Search
+--
+-- Fixes: #95 (halfvec HNSW indexes need an explicit dimension).
+--
+-- The canonical schema.sql declares embedding columns as bare `halfvec` (no
+-- dimension) so a fresh install works with any embedding provider. pgvector
+-- requires halfvec columns to have a concrete dimension before an HNSW index
+-- can be built. This file is a template operators apply AFTER choosing their
+-- embedding provider.
+--
+-- Usage:
+--   1. Pick your embedding provider and find its vector dimension:
+--      - bge-small-en-v1.5 (default local)  → 384
+--      - nomic-embed-text                   → 768
+--      - text-embedding-3-small (OpenAI)    → 1536
+--      - text-embedding-3-large (OpenAI)    → 3072
+--      - (custom) → whatever your model outputs
+--   2. Edit the three DIMENSION placeholders below to match your provider.
+--   3. Apply: psql "$DATABASE_URL" -f schema/hnsw-indexes.example.sql
+--
+-- You can skip this file entirely if:
+--   - You're not using embeddings (EMBEDDING_PROVIDER=none), OR
+--   - Your warm tier is small enough that seq-scan similarity is fine
+--     (typically <50k rows; pgvector's bare halfvec supports cosine distance
+--     via the <=> operator without an index — just slower).
+--
+-- Re-running is safe: ALTER COLUMN TYPE uses USING to cast, and CREATE INDEX
+-- has IF NOT EXISTS. ALTER COLUMN TYPE on a populated column rewrites the
+-- table — plan for maintenance window on large tables.
+
+-- ─── warm_tier ──────────────────────────────────────────────────────────────
+-- Pin warm_tier.embedding to your provider's dimension, then build the HNSW
+-- index for fast cosine similarity search.
+
+ALTER TABLE warm_tier
+  ALTER COLUMN embedding TYPE halfvec(384) USING embedding::halfvec(384);
+
+CREATE INDEX IF NOT EXISTS warm_tier_embedding_idx
+  ON warm_tier USING hnsw (embedding halfvec_cosine_ops);
+
+-- ─── shared_memories ────────────────────────────────────────────────────────
+-- Only needed if you're using cross-agent shared memory pools (otherwise
+-- this table stays empty and the index is harmless but unnecessary).
+
+ALTER TABLE shared_memories
+  ALTER COLUMN embedding TYPE halfvec(384) USING embedding::halfvec(384);
+
+CREATE INDEX IF NOT EXISTS shared_memories_embedding_idx
+  ON shared_memories USING hnsw (embedding halfvec_cosine_ops);
+
+-- ─── Verify ─────────────────────────────────────────────────────────────────
+-- SELECT attname, format_type(atttypid, atttypmod) AS type
+-- FROM pg_attribute
+-- WHERE attrelid = 'warm_tier'::regclass AND attname = 'embedding';
+-- Expected: embedding | halfvec(384)  (or whatever dimension you chose)
+--
+-- SELECT indexname FROM pg_indexes
+-- WHERE tablename IN ('warm_tier', 'shared_memories')
+--   AND indexname LIKE '%embedding_idx';
+-- Expected: warm_tier_embedding_idx, shared_memories_embedding_idx

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -102,7 +102,14 @@ CREATE INDEX IF NOT EXISTS warm_tier_agent_id_idx   ON warm_tier (agent_id);
 CREATE INDEX IF NOT EXISTS warm_tier_tsv_idx        ON warm_tier USING GIN (content_tsv);
 CREATE INDEX IF NOT EXISTS warm_tier_code_tsv_idx   ON warm_tier USING GIN (content_code_tsv);
 CREATE INDEX IF NOT EXISTS warm_tier_hot_ids_idx    ON warm_tier USING GIN (source_hot_ids);
-CREATE INDEX IF NOT EXISTS warm_tier_embedding_idx  ON warm_tier USING hnsw (embedding halfvec_cosine_ops);
+-- HNSW index on warm_tier.embedding intentionally omitted here (#95): pgvector
+-- requires halfvec columns to have an explicit dimension spec before an HNSW
+-- index can be built, and the dimension is provider-specific (384 for
+-- bge-small-en-v1.5, 1536 for text-embedding-3-small, 768 for nomic-embed,
+-- etc.). After deploying, operators who use embeddings should apply
+-- schema/hnsw-indexes.example.sql (edit to match their provider's dimension).
+-- Without the HNSW index, semantic search falls back to seq scan — functional
+-- but slower for large warm tiers.
 CREATE INDEX IF NOT EXISTS warm_tier_time_idx       ON warm_tier (agent_id, time_start, time_end);
 CREATE INDEX IF NOT EXISTS warm_tier_importance_idx ON warm_tier (agent_id, importance DESC);
 CREATE INDEX IF NOT EXISTS warm_tier_namespace_idx  ON warm_tier (agent_id, namespace);
@@ -464,7 +471,9 @@ CREATE TABLE IF NOT EXISTS shared_memories (
 CREATE INDEX IF NOT EXISTS shared_memories_pool_idx      ON shared_memories (pool_id);
 CREATE INDEX IF NOT EXISTS shared_memories_source_idx    ON shared_memories (source_agent_id);
 CREATE INDEX IF NOT EXISTS shared_memories_tsv_idx       ON shared_memories USING GIN (content_tsv);
-CREATE INDEX IF NOT EXISTS shared_memories_embedding_idx ON shared_memories USING hnsw (embedding halfvec_cosine_ops);
+-- HNSW index on shared_memories.embedding intentionally omitted here (#95);
+-- see warm_tier above for the same reasoning. Apply via
+-- schema/hnsw-indexes.example.sql after choosing a dimension.
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- agent_reputation — per-domain reputation scores for cross-agent trust


### PR DESCRIPTION
## Summary

- Ships **Phase 2** of the ROADMAP to npm (namespaces, cold tier search/restore, memory budgeting, adaptive sleep advisory).
- **Fixes #95**: \`schema.sql\` no longer issues failing \`CREATE INDEX\` statements for HNSW on bare halfvec columns. The two indexes now live in a new \`schema/hnsw-indexes.example.sql\` that operators apply after pinning their embedding dimension.
- First release via **npm Trusted Publishing (OIDC)** — validates the infrastructure from Sprint A + PR #97 end-to-end.

## Files

- \`package.json\` — \`3.0.0-beta.3\` → \`3.0.0-beta.4\`
- \`CHANGELOG.md\` — new beta.4 entry (Added / Changed / Known gaps)
- \`ROADMAP.md\` — \`Where We Are Today\` bumped; Phase 1 remaining items collapsed (all shipped); Phase 2 marked COMPLETE with per-item PR references; #13 two-pass triage flagged as the remaining partial item
- \`schema/schema.sql\` — remove the two failing \`CREATE INDEX ... USING hnsw\` statements; comment with rationale and pointer to the example
- \`schema/hnsw-indexes.example.sql\` (new) — template for operators with embeddings (covers 384, 768, 1536, 3072 dimensions)

## Phase 2 scorecard (closed on merge)

- ✅ Memory namespaces (#16) — PRs #100, #101
- ✅ Cold tier search + restoration (#14) — PR #102
- ✅ Memory budgeting — PR #103
- ✅ Adaptive sleep scheduling — PR #104
- ✅ Per-agent scoring weights (#17) — shipped in v2.4
- ⚠️ Multi-model revision (#13) — basic split plumbed; two-pass triage variant deferred

## Issue cleanup (closed since beta.3)

#10, #14, #16, #17, #18, #35, #43, #46, #50 — all shipped but not previously closed on the tracker. Status comments added to #13 and #41 documenting current state without closing.

## Test plan

- [ ] CI type-check / lint / build pass
- [ ] CI test-integration (Node 20, 22) — the namespace / cold / budgeting / advisory test suites all run
- [ ] CI test-rls passes — RLS still enforced under all new per-namespace paths
- [ ] On merge + tag \`v3.0.0-beta.4\`, release workflow publishes via OIDC (Trusted Publishing) — **no \`NPM_TOKEN\` used**. Validates #97 end-to-end.
- [ ] GitHub Release auto-created with the CHANGELOG excerpt for beta.4

## Follow-up after merge

1. Tag \`v3.0.0-beta.4\` on \`main\` — triggers the release workflow.
2. If OIDC publish succeeds: delete the \`NPM_TOKEN\` repo secret. If it fails: diagnose, re-tag if needed.
3. Next sprint candidates: close remaining Phase 2 work (#13 two-pass triage), start Phase 3 / security (#41), or begin Phase 4 ROADMAP items.