### PR TITLE
ci(release): upgrade npm + reinstate NODE_AUTH_TOKEN fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,16 +26,24 @@ jobs:
           node-version: "22"
           cache: npm
           registry-url: "https://registry.npmjs.org"
+      # Upgrade npm to the latest. Trusted Publishing requires npm >= 11.5.1;
+      # the npm bundled with Node 22 on GitHub runners is 10.x, which does NOT
+      # speak the OIDC publish flow — it would silently fall through to token
+      # auth and 404 against npm. Explicitly upgrading guarantees TP works.
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
-      # Auth via npm Trusted Publishing (OIDC). The package exists on npm
-      # as of v3.0.0-beta.3, so a trusted publisher can be configured for
-      # it on npmjs.com (Packages → @salishforge/memforge → Settings →
-      # Trusted publishing). Once configured, no NODE_AUTH_TOKEN is needed:
-      # npm CLI uses the GitHub Actions OIDC token (id-token: write, above)
-      # to authenticate directly.
+      # Auth via npm Trusted Publishing (OIDC). Configured on npmjs.com at
+      # Packages → @salishforge/memforge → Settings → Trusted publishing.
+      # NODE_AUTH_TOKEN is kept as a belt-and-suspenders fallback: if OIDC
+      # ever fails (registry outage, config drift, token request timeout),
+      # the token path takes over so releases aren't blocked on a single
+      # auth mechanism. Delete the NPM_TOKEN secret once OIDC has shipped
+      # a few releases successfully.
       - name: Publish package
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Summary

Unblocks the v3.0.0-beta.4 release. The first attempt failed with npm 404 under OIDC despite a correctly-configured Trusted Publisher.

**Root cause**: npm Trusted Publishing requires **npm >= 11.5.1**. The bundled npm with Node 22 on GitHub runners is 10.x, which silently falls through to token auth and 404s when no token is present.

## Fix

Two changes to \`.github/workflows/release.yml\`:

1. \`npm install -g npm@latest\` before the publish step — guarantees the runner has a TP-capable npm.
2. Reinstate \`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` as a **belt-and-suspenders fallback**. If OIDC works (expected now), the token is ignored. If OIDC fails for any reason, the token keeps us shipping.

## Plan

1. Merge this PR.
2. Delete + retag \`v3.0.0-beta.4\` on main (destructive but safe — nothing was published yet).
3. Release workflow runs with the fixed publish step.
4. On successful OIDC publish: delete the \`NPM_TOKEN\` secret from the repo (clean up).

## Test plan

- [ ] CI passes (this PR's CI doesn't exercise the release workflow — the release.yml path is triggered by tag push, not PRs)
- [ ] After merge + retag, the release workflow publishes successfully, provenance is attested via OIDC, and the GitHub Release is created automatically.