### PR TITLE
ci: activate npm via corepack + manual OIDC auth test workflow

### DIFF
--- a/.github/workflows/npm-auth-test.yml
+++ b/.github/workflows/npm-auth-test.yml
@@ -1,0 +1,59 @@
+name: Test npm publish auth (manual)
+
+# Manual-only workflow to validate that npm Trusted Publishing (OIDC) works
+# end-to-end before committing to it for the real release pipeline.
+#
+# Runs `npm publish --dry-run --access public --provenance` with NO
+# NODE_AUTH_TOKEN set — so if the dry-run succeeds, OIDC is authenticating
+# correctly and we can safely remove the token fallback from release.yml
+# (and delete the NPM_TOKEN repo secret).
+#
+# If this workflow fails at the publish step with 401/403/404:
+# - Either corepack didn't successfully activate npm >= 11.5.1, or
+# - The trusted publisher on npm.com isn't accepting the OIDC claim.
+# Inspect the "Report npm version" step to confirm npm is current.
+#
+# Trigger: Actions tab → "Test npm publish auth (manual)" → Run workflow.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test-auth:
+    name: Dry-run publish via corepack-activated npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Activate npm via corepack
+        run: |
+          corepack enable
+          corepack prepare npm@latest --activate
+          echo "✓ corepack activation complete"
+
+      - name: Report npm version
+        run: |
+          echo "node version: $(node --version)"
+          echo "npm version:  $(npm --version)"
+          # Trusted Publishing requires npm >= 11.5.1. Fail fast if corepack
+          # activation didn't give us a current npm.
+          npm --version | awk -F. '{ if ($1 < 11 || ($1 == 11 && $2 < 5)) { print "FAIL: npm < 11.5"; exit 1 } }'
+
+      - name: Install deps and build
+        run: |
+          npm ci
+          npm run build
+
+      - name: Dry-run publish (OIDC only, no NODE_AUTH_TOKEN)
+        run: npm publish --dry-run --access public --provenance
+        # Intentionally no `env: NODE_AUTH_TOKEN: ...` — this is the whole point:
+        # validate that trusted publishing alone can authenticate the publish.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,20 +26,30 @@ jobs:
           node-version: "22"
           cache: npm
           registry-url: "https://registry.npmjs.org"
+      # Activate npm >= 11.5.1 via corepack so Trusted Publishing (OIDC)
+      # works. The npm bundled with Node 22 on runners is 10.x, which does
+      # NOT speak the TP publish flow. corepack is Node's built-in package
+      # manager version manager — it swaps npm cleanly without the
+      # self-replace corruption that `npm install -g npm@latest` causes.
+      - name: Activate npm via corepack
+        run: |
+          corepack enable
+          corepack prepare npm@latest --activate
       - run: npm ci
       - run: npm run build
       # Auth strategy:
-      # - NODE_AUTH_TOKEN (npm Automation token) is the primary path today —
-      #   proven working across beta.3 and beta.4 releases.
-      # - `--provenance` still creates an OIDC-signed attestation published
-      #   to the sigstore transparency log (uses id-token: write above).
-      # - Trusted Publishing (OIDC-authenticated publish, not just
-      #   provenance) is configured on npmjs.com but currently falls through
-      #   to the token because the npm bundled with Node 22 runners may not
-      #   yet support the TP flow. Once runners ship npm >= 11.5.1 or
-      #   corepack is wired in for a specific npm version, NODE_AUTH_TOKEN
-      #   can be removed and the NPM_TOKEN secret deleted. Tracked as a
-      #   future follow-up — ship today, polish OIDC later.
+      # - Trusted Publishing (OIDC) is the primary path now that npm is
+      #   current via corepack. npm CLI requests an OIDC token from the
+      #   GitHub Actions runner (id-token: write) and uses it to authenticate
+      #   against npm's registry, which validates against the trusted
+      #   publisher configured at Packages → @salishforge/memforge →
+      #   Settings → Trusted publishing.
+      # - NODE_AUTH_TOKEN remains as a belt-and-suspenders fallback: if OIDC
+      #   fails for any reason (registry outage, config drift), the token
+      #   keeps us shipping. Once OIDC has validated across a few releases,
+      #   remove the env var below and delete the NPM_TOKEN secret.
+      # - `--provenance` creates OIDC-signed attestations in sigstore
+      #   regardless of auth path — the attestation only needs id-token: write.
       - name: Publish package
         run: npm publish --access public --provenance
         env:


### PR DESCRIPTION
## Summary

Phase 1 of the npm Trusted Publishing migration.

GitHub runners bundle npm 10.x with Node 22, but Trusted Publishing requires >= 11.5.1. \`corepack\` (built into Node 16.9+) is the sanctioned way to swap package-manager versions — unlike \`npm install -g npm@latest\`, it doesn't self-corrupt the running npm because it symlinks a separate install rather than replacing files in-place.

## Changes

### \`.github/workflows/release.yml\`

Add \`corepack enable && corepack prepare npm@latest --activate\` between \`setup-node\` and \`npm ci\`. TP is now flagged as the primary auth path; \`NODE_AUTH_TOKEN\` stays as belt-and-suspenders fallback until we've validated across a few real releases.

### \`.github/workflows/npm-auth-test.yml\` (new)

Manual-only workflow (\`workflow_dispatch\`) that runs \`npm publish --dry-run --access public --provenance\` with **no \`NODE_AUTH_TOKEN\` set** — pure OIDC. Also reports the activated npm version and fails fast if corepack didn't give us >= 11.5. Safe to run any time: dry-run skips the actual PUT.

## Plan

1. Merge this PR.
2. **Actions tab → "Test npm publish auth (manual)" → Run workflow.**
3. If the dry-run succeeds (OIDC works):
   - Open a follow-up PR dropping \`NODE_AUTH_TOKEN\` from \`release.yml\`.
   - Delete the \`NPM_TOKEN\` repo secret.
4. If corepack can't activate a current npm: fall back to downloading npm via tarball (documented in this turn's earlier discussion).

## Why an auth test workflow vs just trying the next release

Validating via \`workflow_dispatch\` decouples the OIDC experiment from a version bump. A failed auth during a real tag would either burn the version number (cannot republish) or require another destructive retag cycle. Dry-run lets us confirm auth without consequences.

## Test plan

- [ ] CI on this PR passes (workflow files parse, release.yml YAML still valid)
- [ ] After merge: manual invocation of \`npm-auth-test.yml\` succeeds
- [ ] npm version in the workflow log shows >= 11.5 (corepack activation verified)
- [ ] Follow-up PR can remove the token once validated