### PR TITLE
ci: npm prefix-install for Trusted Publishing (replaces corepack)

### DIFF
--- a/.github/workflows/npm-auth-test.yml
+++ b/.github/workflows/npm-auth-test.yml
@@ -34,18 +34,22 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Activate npm via corepack
+      - name: Install recent npm to a separate prefix
+        # corepack's `prepare npm@latest` gave us npm 10.9 on Node 22 (bundled
+        # version wins). Install npm 11+ to a dedicated prefix and prepend its
+        # .bin to PATH so subsequent steps pick up the fresh npm without
+        # corrupting the Node-bundled one.
         run: |
-          corepack enable
-          corepack prepare npm@latest --activate
-          echo "✓ corepack activation complete"
+          mkdir -p /tmp/fresh-npm
+          npm install --prefix /tmp/fresh-npm --no-save --no-package-lock npm@latest
+          echo "/tmp/fresh-npm/node_modules/.bin" >> $GITHUB_PATH
 
       - name: Report npm version
         run: |
           echo "node version: $(node --version)"
           echo "npm version:  $(npm --version)"
-          # Trusted Publishing requires npm >= 11.5.1. Fail fast if corepack
-          # activation didn't give us a current npm.
+          # Trusted Publishing requires npm >= 11.5.1. Fail fast if the fresh
+          # install didn't give us a current npm.
           npm --version | awk -F. '{ if ($1 < 11 || ($1 == 11 && $2 < 5)) { print "FAIL: npm < 11.5"; exit 1 } }'
 
       - name: Install deps and build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,15 +26,18 @@ jobs:
           node-version: "22"
           cache: npm
           registry-url: "https://registry.npmjs.org"
-      # Activate npm >= 11.5.1 via corepack so Trusted Publishing (OIDC)
-      # works. The npm bundled with Node 22 on runners is 10.x, which does
-      # NOT speak the TP publish flow. corepack is Node's built-in package
-      # manager version manager — it swaps npm cleanly without the
-      # self-replace corruption that `npm install -g npm@latest` causes.
-      - name: Activate npm via corepack
+      # Install npm >= 11.5.1 to a dedicated prefix so Trusted Publishing
+      # (OIDC) works. The npm bundled with Node 22 on runners is 10.x, which
+      # does NOT speak the TP publish flow. Installing to a separate prefix
+      # (not global) avoids the self-replace corruption that
+      # `npm install -g npm@latest` causes. Corepack was tried first but
+      # gave us 10.9 — either it doesn't fully support npm in Node 22 or
+      # its `@latest` resolution is stale.
+      - name: Install recent npm to a separate prefix
         run: |
-          corepack enable
-          corepack prepare npm@latest --activate
+          mkdir -p /tmp/fresh-npm
+          npm install --prefix /tmp/fresh-npm --no-save --no-package-lock npm@latest
+          echo "/tmp/fresh-npm/node_modules/.bin" >> $GITHUB_PATH
       - run: npm ci
       - run: npm run build
       # Auth strategy:


### PR DESCRIPTION
## Summary

The corepack experiment in PR #108 ran the manual auth test and corepack activated npm **10.9.7** — not the >= 11.5 that npm Trusted Publishing requires. Either corepack's npm support is incomplete on Node 22 or its \`@latest\` resolution is stale.

This PR swaps corepack for a **\`npm install --prefix\` install into a dedicated directory**, then prepends its \`.bin\` to \`$GITHUB_PATH\`. Clean, doesn't corrupt the bundled npm (unlike \`npm install -g\`), and guaranteed to give us whatever npm's real latest is.

## Changes

Applied to both workflows identically:

- \`.github/workflows/release.yml\` — swap the \`Activate npm via corepack\` step for \`Install recent npm to a separate prefix\`.
- \`.github/workflows/npm-auth-test.yml\` — same swap; also preserves the fail-fast version check.

## Plan

1. Merge.
2. Re-trigger **"Test npm publish auth (manual)"** from the Actions tab.
3. If \`npm --version\` in the log shows >= 11.5 and the dry-run publish succeeds → OIDC is working. Follow-up PR drops \`NODE_AUTH_TOKEN\` and deletes the \`NPM_TOKEN\` secret.
4. If it still fails: investigate the specific error (possibly the Trusted Publisher config on npm.com has a mismatch).

## Note on force-push

The branch got amended + force-pushed once while fixing a missed edit. Used \`--force-with-lease\` for safety. Branch is new and unshared.