### PR TITLE
ci: specify npm dist-tag for prerelease publishes

### DIFF
--- a/.github/workflows/npm-auth-test.yml
+++ b/.github/workflows/npm-auth-test.yml
@@ -58,6 +58,11 @@ jobs:
           npm run build
 
       - name: Dry-run publish (OIDC only, no NODE_AUTH_TOKEN)
-        run: npm publish --dry-run --access public --provenance
+        # `--tag beta` satisfies npm 11's requirement that prerelease versions
+        # (like 3.0.0-beta.4) specify an explicit dist-tag instead of hijacking
+        # `latest`. The real release workflow derives the tag dynamically from
+        # the version; this test hardcodes `beta` since the current version is
+        # a beta and we're only validating the auth handshake.
+        run: npm publish --dry-run --access public --provenance --tag beta
         # Intentionally no `env: NODE_AUTH_TOKEN: ...` — this is the whole point:
         # validate that trusted publishing alone can authenticate the publish.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,30 @@ jobs:
           echo "/tmp/fresh-npm/node_modules/.bin" >> $GITHUB_PATH
       - run: npm ci
       - run: npm run build
+      # Derive the npm dist-tag from the package.json version. npm >= 11
+      # refuses to publish a prerelease version (e.g. 3.0.0-beta.4) without
+      # an explicit --tag, otherwise the prerelease would hijack `latest`.
+      # Stable versions (no hyphen suffix) publish to `latest`; prereleases
+      # publish to the channel named in the suffix (beta, alpha, rc, next).
+      - name: Determine dist-tag from version
+        id: dist_tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *"-"* ]]; then
+            TAG=$(echo "$VERSION" | sed -E 's/^[^-]+-([a-z]+).*/\1/')
+            [ -z "$TAG" ] && TAG="next"
+          else
+            TAG="latest"
+          fi
+          echo "Publishing ${VERSION} with dist-tag ${TAG}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
       # Auth strategy:
-      # - Trusted Publishing (OIDC) is the primary path now that npm is
-      #   current via corepack. npm CLI requests an OIDC token from the
-      #   GitHub Actions runner (id-token: write) and uses it to authenticate
-      #   against npm's registry, which validates against the trusted
-      #   publisher configured at Packages → @salishforge/memforge →
-      #   Settings → Trusted publishing.
+      # - Trusted Publishing (OIDC) is the primary path now that npm 11+ is
+      #   available via prefix-install. npm CLI requests an OIDC token from
+      #   the GitHub Actions runner (id-token: write) and uses it to auth
+      #   against npm, which validates against the trusted publisher
+      #   configured at Packages → @salishforge/memforge → Settings →
+      #   Trusted publishing.
       # - NODE_AUTH_TOKEN remains as a belt-and-suspenders fallback: if OIDC
       #   fails for any reason (registry outage, config drift), the token
       #   keeps us shipping. Once OIDC has validated across a few releases,
@@ -54,7 +71,7 @@ jobs:
       # - `--provenance` creates OIDC-signed attestations in sigstore
       #   regardless of auth path — the attestation only needs id-token: write.
       - name: Publish package
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

Last blocker for OIDC Trusted Publishing. npm 11+ refuses to publish prerelease versions (like \`3.0.0-beta.4\`) without an explicit \`--tag <channel>\` — otherwise the prerelease would hijack the \`latest\` dist-tag.

## Changes

### \`release.yml\`

New step **"Determine dist-tag from version"** that parses \`package.json\` and outputs:
- \`latest\` for stable versions (no \`-suffix\`)
- \`beta\` / \`alpha\` / \`rc\` / etc. from the prerelease channel suffix
- \`next\` as a fallback for non-standard suffixes

Publish step now passes \`--tag \${{ steps.dist_tag.outputs.tag }}\`.

### \`npm-auth-test.yml\`

Hardcodes \`--tag beta\` for the dry-run — simpler since this workflow only validates the auth handshake.

## Context

Previous auth test run confirmed:
- **npm 11.12.1 active** via prefix-install ✅
- **Version fail-fast passed** ✅
- **Deps + build succeeded** ✅
- **Dry-run publish reached validation** — only error was npm's prerelease-tag enforcement

Which means **OIDC auth is working** — we just need to satisfy the tag-specification rule.

## Plan

1. Merge.
2. Re-trigger "Test npm publish auth (manual)". Expected: dry-run succeeds.
3. Follow-up PR drops \`NODE_AUTH_TOKEN\` from release.yml.
4. Delete \`NPM_TOKEN\` repo secret.

## Test plan

- [ ] CI on this PR passes (YAML parses, release.yml structure still valid)
- [ ] After merge, auth-test workflow succeeds (shows \`tarball written to stdout\` from \`npm publish --dry-run\`)