### PR TITLE
ci: drop NODE_AUTH_TOKEN — OIDC Trusted Publishing validated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,23 +57,19 @@ jobs:
           fi
           echo "Publishing ${VERSION} with dist-tag ${TAG}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-      # Auth strategy:
-      # - Trusted Publishing (OIDC) is the primary path now that npm 11+ is
-      #   available via prefix-install. npm CLI requests an OIDC token from
-      #   the GitHub Actions runner (id-token: write) and uses it to auth
-      #   against npm, which validates against the trusted publisher
-      #   configured at Packages → @salishforge/memforge → Settings →
-      #   Trusted publishing.
-      # - NODE_AUTH_TOKEN remains as a belt-and-suspenders fallback: if OIDC
-      #   fails for any reason (registry outage, config drift), the token
-      #   keeps us shipping. Once OIDC has validated across a few releases,
-      #   remove the env var below and delete the NPM_TOKEN secret.
-      # - `--provenance` creates OIDC-signed attestations in sigstore
-      #   regardless of auth path — the attestation only needs id-token: write.
+      # Auth via npm Trusted Publishing (OIDC). Validated end-to-end by
+      # the manual `npm-auth-test.yml` workflow — dry-run publish succeeds
+      # with NO token set, proving OIDC alone authenticates. The npm CLI
+      # requests an OIDC token from the GitHub Actions runner (id-token:
+      # write permission) and exchanges it with npm's registry, which
+      # validates against the trusted publisher configured at Packages →
+      # @salishforge/memforge → Settings → Trusted publishing.
+      #
+      # `--provenance` signs an attestation into the sigstore transparency
+      # log so downstream consumers can verify the release came from this
+      # specific repo + workflow. Requires id-token: write (same claim).
       - name: Publish package
         run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Summary

OIDC Trusted Publishing is now validated end-to-end. The manual auth-test workflow (\`npm-auth-test.yml\`) completed successfully with the dry-run publish step running against OIDC alone — **no \`NODE_AUTH_TOKEN\` set**, no token auth involved.

This PR removes the token fallback from the release workflow. Subsequent releases authenticate purely via OIDC.

## Changes

- \`.github/workflows/release.yml\` — remove the \`env: NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` block from the publish step. Comment updated to reflect OIDC as the sole auth path.
- \`--provenance\` signing still works (uses the same \`id-token: write\` permission for sigstore attestations).

## Follow-up (post-merge)

Delete the \`NPM_TOKEN\` secret from the repo:
https://github.com/salishforge/memforge/settings/secrets/actions

Once that's done, the project has no long-lived npm credentials at all — all releases are cryptographically bound to this specific workflow in this specific repo via OIDC.

## Test plan

- [ ] CI on this PR passes (no functional change, just env removal)
- [ ] Next tag push (e.g. v3.0.1 or v3.0.0-beta.5) publishes successfully via OIDC
- [ ] \`NPM_TOKEN\` secret deleted from repo settings