### PR TITLE
fix: security hardening, auth model, and pgvector compatibility

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -231,9 +231,10 @@ export function createApp(deps: AppDependencies): express.Express {
     res.type('html').send(cacheDashboardHtml());
   });
 
-  // ─── Auth — all /memory routes require a valid Bearer token ────────────
+  // ─── Auth — all /memory and /pool routes require a valid Bearer token ───
 
   app.use('/memory', bearerAuth);
+  app.use('/pool', bearerAuth);
 
   // ─── Routes ────────────────────────────────────────────────────────────
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,8 +1,10 @@
-// OAuth2 Bearer token + scope authorization middleware for MemForge
-// Calls the OAuth2 introspect endpoint, caches results 30s, enforces scopes.
+// Bearer token authentication middleware for MemForge
+// Supports two modes:
+//   1. Simple token: compare against MEMFORGE_TOKEN (default)
+//   2. OAuth2 introspect: validate against external OAuth2 server (OAUTH2_REQUIRED=true)
 
 import type { Request, Response, NextFunction } from 'express';
-import { createHash } from 'crypto';
+import { createHash, timingSafeEqual } from 'crypto';
 import { getLogger } from './logger.js';
 import { OAuthIntrospectSchema } from './schemas.js';
 import type { ValidatedOAuthIntrospect } from './schemas.js';
@@ -18,20 +20,22 @@ declare global {
   }
 }
 
+const MEMFORGE_TOKEN = process.env['MEMFORGE_TOKEN'] ?? '';
+const OAUTH2_REQUIRED = process.env['OAUTH2_REQUIRED'] === 'true';
+
 const INTROSPECT_URL =
   process.env['OAUTH2_INTROSPECT_URL'] ?? 'http://localhost:3005/oauth2/introspect';
 
-// Validate introspect URL at startup
-try {
-  const parsed = new URL(INTROSPECT_URL);
-  if (!['http:', 'https:'].includes(parsed.protocol)) {
-    throw new Error('must use http or https');
+if (OAUTH2_REQUIRED) {
+  try {
+    const parsed = new URL(INTROSPECT_URL);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new Error('must use http or https');
+    }
+  } catch (err) {
+    throw new Error(`Invalid OAUTH2_INTROSPECT_URL: ${(err as Error).message}`);
   }
-} catch (err) {
-  throw new Error(`Invalid OAUTH2_INTROSPECT_URL: ${(err as Error).message}`);
 }
-
-const REQUIRED = process.env['OAUTH2_REQUIRED'] !== 'false';
 
 interface TokenInfo {
   active: boolean;
@@ -53,9 +57,19 @@ setInterval(() => {
   }
 }, 60_000).unref();
 
+function constantTimeEqual(a: string, b: string): boolean {
+  const ha = createHash('sha256').update(a).digest();
+  const hb = createHash('sha256').update(b).digest();
+  return timingSafeEqual(ha, hb);
+}
+
 /**
  * Express middleware: validate Bearer token and set req.oauth2.
- * If OAUTH2_REQUIRED=false, unauthenticated requests pass through.
+ *
+ * Auth modes (checked in order):
+ *   1. OAUTH2_REQUIRED=true → introspect against external server
+ *   2. MEMFORGE_TOKEN set → constant-time compare bearer token
+ *   3. Neither → unauthenticated pass-through (dev/test only)
  */
 export async function bearerAuth(
   req: Request,
@@ -63,8 +77,11 @@ export async function bearerAuth(
   next: NextFunction,
 ): Promise<void> {
   const authHeader = req.headers['authorization'];
-  if (!authHeader?.startsWith('Bearer ')) {
-    if (!REQUIRED) {
+  const hasBearer = authHeader?.startsWith('Bearer ');
+
+  // No bearer token provided
+  if (!hasBearer) {
+    if (!OAUTH2_REQUIRED && !MEMFORGE_TOKEN) {
       req.oauth2 = { client_id: 'anonymous', scope: 'memforge:read memforge:write' };
       next();
       return;
@@ -73,10 +90,22 @@ export async function bearerAuth(
     return;
   }
 
-  const token = authHeader.slice(7);
+  const token = authHeader!.slice(7);
+
+  // Mode 1: Simple token comparison (MEMFORGE_TOKEN)
+  if (MEMFORGE_TOKEN && !OAUTH2_REQUIRED) {
+    if (constantTimeEqual(token, MEMFORGE_TOKEN)) {
+      req.oauth2 = { client_id: 'token', scope: 'memforge:read memforge:write' };
+      next();
+      return;
+    }
+    res.status(401).json({ ok: false, error: 'Invalid token' });
+    return;
+  }
+
+  // Mode 2: OAuth2 introspect
   const tokenKey = createHash('sha256').update(token).digest('hex');
 
-  // Cache hit (keyed by hash to avoid storing cleartext tokens in memory)
   const cached = TOKEN_CACHE.get(tokenKey);
   if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS) {
     if (!cached.active) {
@@ -88,7 +117,6 @@ export async function bearerAuth(
     return;
   }
 
-  // Introspect
   let data: ValidatedOAuthIntrospect;
   try {
     const response = await fetch(INTROSPECT_URL, {
@@ -111,7 +139,6 @@ export async function bearerAuth(
     return;
   }
 
-  // Evict oldest entries if cache is full (prevents memory exhaustion from token spray)
   if (TOKEN_CACHE.size >= CACHE_MAX_SIZE) {
     const firstKey = TOKEN_CACHE.keys().next().value;
     if (firstKey !== undefined) TOKEN_CACHE.delete(firstKey);

--- a/src/db.ts
+++ b/src/db.ts
@@ -47,6 +47,18 @@ export function getPool(databaseUrl?: string): Pool {
   return _pool;
 }
 
+let _vectorCast: 'halfvec' | 'vector' | null = null;
+
+/** Returns 'halfvec' if pgvector supports it (>=0.7), otherwise 'vector'. */
+export async function getVectorCast(pool: Pool): Promise<'halfvec' | 'vector'> {
+  if (_vectorCast) return _vectorCast;
+  const result = await pool.query<{ exists: boolean }>(
+    `SELECT EXISTS(SELECT 1 FROM pg_type WHERE typname = 'halfvec') AS exists`,
+  );
+  _vectorCast = result.rows[0]?.exists ? 'halfvec' : 'vector';
+  return _vectorCast;
+}
+
 /** Call once on shutdown to drain the pool cleanly. */
 export async function closePool(): Promise<void> {
   if (_healthCheckTimer) {

--- a/src/memory-manager.ts
+++ b/src/memory-manager.ts
@@ -6,7 +6,7 @@
 
 import { createHash } from 'crypto';
 import { Pool } from 'pg';
-import { getPool } from './db.js';
+import { getPool, getVectorCast } from './db.js';
 import { emitWebhookEvent } from './webhooks.js';
 import { NoOpEmbeddingProvider } from './embedding.js';
 import type { EmbeddingProvider } from './embedding.js';
@@ -189,6 +189,7 @@ export class MemoryManager {
   private readonly llm: LLMProvider | null;
   private readonly audit: AuditChain | null;
   private readonly sleepLocks = new Map<string, Promise<SleepCycleResult>>();
+  private vectorCast: 'halfvec' | 'vector' | null = null;
 
   constructor(config: Partial<MemForgeConfig> = {}) {
     this.config = { ...DEFAULTS, ...config };
@@ -196,6 +197,11 @@ export class MemoryManager {
     this.embedder = this.config.embeddingProvider ?? new NoOpEmbeddingProvider();
     this.llm = this.config.llmProvider ?? null;
     this.audit = this.config.auditChain ?? null;
+  }
+
+  private async vcast(): Promise<string> {
+    if (!this.vectorCast) this.vectorCast = await getVectorCast(this.pool);
+    return this.vectorCast;
   }
 
   /** Whether vector search is available (embedding provider is configured). */
@@ -449,9 +455,9 @@ Ranking (numbers only):`;
                FROM shared_memories WHERE pool_id = $1 AND content_tsv @@ plainto_tsquery('english', $2)
                ORDER BY rank DESC LIMIT $3`
             : `SELECT id, content, summary, metadata, published_at as consolidated_at, source_agent_id, hop_count, base_confidence, importance,
-                      (1 - (embedding <=> $2::halfvec)) * importance AS rank
+                      (1 - (embedding <=> $2::${await this.vcast()})) * importance AS rank
                FROM shared_memories WHERE pool_id = $1 AND embedding IS NOT NULL
-               ORDER BY embedding <=> $2::halfvec LIMIT $3`,
+               ORDER BY embedding <=> $2::${await this.vcast()} LIMIT $3`,
           mode === 'keyword' || mode === 'code'
             ? [pool.pool_id, searchText, Math.min(resolvedLimit, 10)]
             : [pool.pool_id, `[${(await this.embedder.embed(searchText)).join(',')}]`, Math.min(resolvedLimit, 10)],
@@ -763,13 +769,13 @@ Ranking (numbers only):`;
 
     const { rows } = await this.pool.query<QueryResult>(
       `SELECT id, content, summary, metadata, consolidated_at, time_start, time_end,
-              (1 - (embedding <=> $2::halfvec)) * (0.5 + 0.5 * importance) AS rank
+              (1 - (embedding <=> $2::${await this.vcast()})) * (0.5 + 0.5 * importance) AS rank
        FROM warm_tier
        WHERE agent_id = $1
          AND namespace = $3
          AND embedding IS NOT NULL
          ${timeFilter}
-       ORDER BY embedding <=> $2::halfvec
+       ORDER BY embedding <=> $2::${await this.vcast()}
        LIMIT $${limitIdx}`,
       params,
     );
@@ -1146,7 +1152,7 @@ Ranking (numbers only):`;
           // Warm rows inherit the namespace of the hot rows they were consolidated from.
           const warmRow = await client.query<{ id: bigint }>(
             `INSERT INTO warm_tier (agent_id, content, summary, source_hot_ids, metadata, embedding, time_start, time_end, outcome_type, namespace, embedding_model)
-             VALUES ($1, $2, $9, $3, $4, $5::halfvec, $6, $7, $8, $10, $11)
+             VALUES ($1, $2, $9, $3, $4, $5::${await this.vcast()}, $6, $7, $8, $10, $11)
              RETURNING id`,
             [agentId, finalContent, batchIds, JSON.stringify(metadata), vectorLiteral, oldest, newest, dominantOutcome, summaryText, ns, embeddingModel],
           );

--- a/src/sleep-cycle.ts
+++ b/src/sleep-cycle.ts
@@ -4,6 +4,7 @@
 // during idle periods. See ARCHITECTURE.md for the full phase breakdown.
 
 import type { Pool } from 'pg';
+import { getVectorCast } from './db.js';
 import { wrapUserContent } from './llm.js';
 import type { LLMProvider } from './llm.js';
 import { safeParseLLMResponse, RevisionResponseSchema } from './schemas.js';
@@ -705,7 +706,7 @@ ${wrapUserContent('related_memories', relatedList || 'None')}`;
          content = $2,
          confidence = $3,
          revision_count = revision_count + 1
-         ${newEmbedding ? ', embedding = $5::halfvec' : ''}
+         ${newEmbedding ? `, embedding = $5::${await getVectorCast(this.pool)}` : ''}
        WHERE id = $1 AND agent_id = $4`,
       newEmbedding
         ? [warmTierId, revisedContent, confidence, agentId, newEmbedding]

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -8,6 +8,7 @@
 //   WEBHOOK_EVENTS — Comma-separated list of events to emit (default: all)
 
 import { getLogger } from './logger.js';
+import { validateProviderUrl } from './schemas.js';
 
 const log = getLogger('webhooks');
 
@@ -24,8 +25,9 @@ let webhookUrl: string | null = null;
 let enabledEvents: Set<WebhookEvent> | null = null;
 
 export function configureWebhooks(url?: string, events?: string): void {
-  webhookUrl = url ?? process.env['WEBHOOK_URL'] ?? null;
-  if (!webhookUrl) return;
+  const raw = url ?? process.env['WEBHOOK_URL'] ?? null;
+  if (!raw) return;
+  webhookUrl = validateProviderUrl(raw, 'Webhook');
 
   const eventList = events ?? process.env['WEBHOOK_EVENTS'] ?? 'consolidated,revised,reflected,evicted,graduated';
   enabledEvents = new Set(eventList.split(',').map((e) => e.trim()) as WebhookEvent[]);


### PR DESCRIPTION
## Summary

- **Security (HIGH)**: Add `MEMFORGE_TOKEN` simple bearer auth mode with constant-time hash comparison (`timingSafeEqual`). Fixes auth model mismatch — system previously required an external OAuth2 introspect server by default, making it either inaccessible or fully open with no middle ground.
- **Security (HIGH)**: Fix `OAUTH2_REQUIRED` default to `false` (was inverted from documentation).
- **Security (HIGH)**: Mount `bearerAuth` middleware on `/pool` routes — they were missing auth, causing permanent 403s.
- **Security (MEDIUM)**: Apply `validateProviderUrl()` SSRF validation to `WEBHOOK_URL`.
- **Compatibility**: Add `getVectorCast()` in `db.ts` that detects `halfvec` support at runtime and falls back to `vector` for pgvector <0.7 deployments. Replaces all hardcoded `::halfvec` casts in `memory-manager.ts` and `sleep-cycle.ts`.

## Changed files (6)

| File | Change |
|------|--------|
| `src/auth.ts` | Add simple token auth mode, fix OAUTH2_REQUIRED default |
| `src/app.ts` | Mount bearerAuth on /pool routes |
| `src/db.ts` | Add getVectorCast() runtime detection |
| `src/memory-manager.ts` | Replace hardcoded halfvec with dynamic vcast() |
| `src/sleep-cycle.ts` | Replace hardcoded halfvec with dynamic getVectorCast() |
| `src/webhooks.ts` | Add SSRF validation on WEBHOOK_URL |

## Test plan

- [x] `tsc --noEmit` — 0 errors
- [x] Integration tests — 24/24 pass
- [x] HTTP API tests — 36/36 pass
- [x] Mock LLM tests — 15/15 pass
- [x] Security tests — 25/25 pass

https://claude.ai/code/session_0116EhmLb79eeBTN8P4wwFC1