### PR TITLE
fix(funding): resolve ZgotmplZ rendering error on FLOSS Fund portal

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "https://fundingjson.org/schema/v1.1.0.json",
-    "version": "v1.1.0",
+    "$schema": "https://fundingjson.org/schema/v1.1.0/funding.schema.json",
     "entity": {
         "type": "individual",
         "role": "maintainer",
@@ -44,7 +43,7 @@
             {
                 "guid": "direct-email",
                 "type": "other",
-                "address": "john@salishforge.com",
+                "address": "mailto:john@salishforge.com",
                 "description": "For grants, compute credits, corporate sponsorships, or larger direct transfers. Reach out via email and I'll route to the appropriate payment method."
             },
             {


### PR DESCRIPTION
## Problem

The FLOSS Fund directory page at `dir.floss.fund/view/project/@github.com/salishforge/memforge` shows `#ZgotmplZ` instead of rendering the project link correctly. This is Go's `html/template` URL sanitizer replacing a non-http/https/mailto value with a safe fragment.

## Root cause

The `direct-email` funding channel had `"address": "john@salishforge.com"` — a bare email without a `mailto:` scheme. When the portal renders this as an `href`, Go's template engine sees a non-URL string and replaces it with `#ZgotmplZ`.

## Fixes

1. **`address`**: `john@salishforge.com` → `mailto:john@salishforge.com` (gives Go a safe `mailto:` scheme)
2. **`$schema`**: Fixed to canonical v1.1.0 path (`/v1.1.0/funding.schema.json`)
3. **`version`**: Removed (v1.1.0 spec uses `$schema` only; `version` was a v1.0.0-era field)

https://claude.ai/code/session_0116EhmLb79eeBTN8P4wwFC1