### PR TITLE
feat(phase5): wire adaptive sleep analytics + skip gating into run()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,24 @@ All notable changes to MemForge are documented here.
   last 3 recorded runs for that phase all had `changes_made = 0`).
   Index `sleep_phase_analytics_agent_idx` on
   `(agent_id, created_at DESC)`. RLS agent isolation policy mirrors the
-  rest of the schema. **Wiring of these helpers into the `run()` loop is
-  deferred to a follow-up** — this PR ships the schema, helpers, and
-  unit-level test coverage so the wiring change has a stable target.
+  rest of the schema.
+
+- **Adaptive Sleep Intelligence (F5) — run() wiring** — every top-level
+  phase invocation in `SleepCycleEngine.run()` is now wrapped with timing
+  and a `recordPhaseAnalytics()` write, populating `sleep_phase_analytics`
+  with one row per phase per cycle. Phase identifiers: `weight-adaptation`,
+  `scoring`, `triage`, `capacity-eviction`, `conflict-resolution`,
+  `revision`, `graph-maintenance`, `entity-dedup`, `reflection`,
+  `cold-purge`, `schema-detection`, `temporal-validation`,
+  `procedure-evolution`, `embedding-migration`, `deprecated-decay`,
+  `epistemic-promotion`, `drift-snapshot`, `audit-archive`. The cleanup /
+  reflection tail — `graph-maintenance`, `entity-dedup`, `reflection`,
+  `schema-detection`, `temporal-validation`, `procedure-evolution`,
+  `embedding-migration`, `deprecated-decay` — additionally consults
+  `shouldSkipPhase()` and short-circuits when the last 3 recorded runs
+  were idle, avoiding unnecessary I/O on quiet agents. Core hot-path
+  phases (weight adaptation, scoring, triage, capacity eviction, conflict
+  resolution, Phase 3 revision, Phase 6 audit archive) always run.
 
 ### Migration
 

--- a/src/sleep-cycle.ts
+++ b/src/sleep-cycle.ts
@@ -119,36 +119,86 @@ export class SleepCycleEngine {
   /**
    * Execute a full sleep cycle for an agent.
    * Phases run sequentially; LLM phases respect the token budget.
+   *
+   * Each top-level phase invocation is wrapped in timing + a
+   * `recordPhaseAnalytics()` write so callers can inspect per-phase
+   * duration/changes via `sleep_phase_analytics`. Phases that are safe to
+   * skip when idle (the cleanup / reflection tail) consult
+   * `shouldSkipPhase()` first: if the last three recorded runs all had
+   * `changes_made = 0`, the phase short-circuits without I/O and without
+   * recording a fresh row (so the skip persists naturally — a write would
+   * just re-anchor the same zero history with a new timestamp).
    */
   async run(agentId: string): Promise<SleepCycleResult> {
     const start = Date.now();
     let tokensUsed = 0;
 
+    // Local helper — wraps a phase call with timing + analytics. Returns
+    // the phase's reported change count so the caller can fold it into
+    // SleepCycleResult. Skippable phases pass skippable=true; non-skippable
+    // (core hot-path) phases must always run.
+    const runPhase = async (
+      phase: string,
+      fn: () => Promise<number>,
+      opts: { skippable?: boolean } = {},
+    ): Promise<number> => {
+      if (opts.skippable && (await this.shouldSkipPhase(agentId, phase))) {
+        log.debug({ agentId, phase }, 'sleep phase skipped — 3 prior idle runs');
+        return 0;
+      }
+      const phaseStart = Date.now();
+      const changes = await fn();
+      await this.recordPhaseAnalytics(
+        agentId,
+        phase,
+        Date.now() - phaseStart,
+        0,
+        changes,
+      );
+      return changes;
+    };
+
     // Phase 0: Autonomous weight adaptation
     await this.throwIfCanceled();
-    await this.phaseWeightAdaptation(agentId);
+    await runPhase('weight-adaptation', async () => {
+      await this.phaseWeightAdaptation(agentId);
+      return 0;
+    });
 
     // Phase 1: Scoring
     await this.throwIfCanceled();
-    const scoresUpdated = await this.phaseScoring(agentId);
+    const scoresUpdated = await runPhase('scoring', () => this.phaseScoring(agentId));
 
     // Phase 2: Triage
     await this.throwIfCanceled();
-    const { evicted, flaggedIds } = await this.phaseTriage(agentId);
+    let evicted = 0;
+    let flaggedIds: bigint[] = [];
+    await runPhase('triage', async () => {
+      const triage = await this.phaseTriage(agentId);
+      evicted = triage.evicted;
+      flaggedIds = triage.flaggedIds;
+      return evicted + flaggedIds.length;
+    });
 
     // Phase 2b: Capacity eviction — enforce per-agent warm_tier hard cap.
     // Runs after threshold eviction so the threshold pass already removed the
     // cheapest evictees; we only evict further if the agent is still over cap.
-    const capacityEvicted = await this.phaseCapacityEviction(agentId);
+    const capacityEvicted = await runPhase('capacity-eviction', () =>
+      this.phaseCapacityEviction(agentId),
+    );
 
     // Phase 2.5: Conflict Resolution — resolve contradicting memories
     await this.throwIfCanceled();
-    const conflictsResolved = await this.phaseConflictResolution(agentId);
+    const conflictsResolved = await runPhase('conflict-resolution', () =>
+      this.phaseConflictResolution(agentId),
+    );
 
     // Phase 3: Revision (bounded by token budget and optional per-cycle cap)
     const maxRevisions = this.config.maxRevisionsPerCycle ?? flaggedIds.length;
     let revised = 0;
     let skipped = 0;
+    const phase3Start = Date.now();
+    const phase3StartTokens = tokensUsed;
     for (const warmId of flaggedIds) {
       if (tokensUsed >= this.config.tokenBudget || revised >= maxRevisions) {
         skipped = flaggedIds.length - revised;
@@ -165,21 +215,41 @@ export class SleepCycleEngine {
         skipped++;
       }
     }
+    await this.recordPhaseAnalytics(
+      agentId,
+      'revision',
+      Date.now() - phase3Start,
+      tokensUsed - phase3StartTokens,
+      revised,
+    );
 
     // Phase 4: Graph maintenance + entity deduplication
     let edgesInvalidated = 0;
     let entitiesMerged = 0;
     if (tokensUsed < this.config.tokenBudget) {
       await this.throwIfCanceled();
-      edgesInvalidated = await this.phaseGraphMaintenance(agentId);
-      entitiesMerged = await this.phaseEntityDedup(agentId);
+      edgesInvalidated = await runPhase(
+        'graph-maintenance',
+        () => this.phaseGraphMaintenance(agentId),
+        { skippable: true },
+      );
+      entitiesMerged = await runPhase(
+        'entity-dedup',
+        () => this.phaseEntityDedup(agentId),
+        { skippable: true },
+      );
     }
 
     // Phase 5: Reflection (optional)
     let didReflect = false;
     if (this.config.includeReflection && tokensUsed < this.config.tokenBudget) {
       await this.throwIfCanceled();
-      didReflect = await this.phaseReflection(agentId);
+      const reflectionChanges = await runPhase(
+        'reflection',
+        async () => ((await this.phaseReflection(agentId)) ? 1 : 0),
+        { skippable: true },
+      );
+      didReflect = reflectionChanges > 0;
     }
 
     // Phase 5b: Cold tier retention purge (optional)
@@ -189,18 +259,32 @@ export class SleepCycleEngine {
     // tail of the cycle, consistent with Phase 6 (audit archive).
     let coldPurged = 0;
     if (this.config.coldRetentionDays) {
-      coldPurged = await this.phaseColdPurge(agentId, this.config.coldRetentionDays);
+      const retentionDays = this.config.coldRetentionDays;
+      coldPurged = await runPhase('cold-purge', () =>
+        this.phaseColdPurge(agentId, retentionDays),
+      );
     }
 
     // Phase 5.5: Schema Detection — find repeated temporal sequences
-    let schemasDetected = 0;
-    schemasDetected = await this.phaseSchemaDetection(agentId);
+    const schemasDetected = await runPhase(
+      'schema-detection',
+      () => this.phaseSchemaDetection(agentId),
+      { skippable: true },
+    );
 
     // Phase 5.6: Temporal Validation — penalize expired memories, flag for revision
-    const temporalExpired = await this.phaseTemporalValidation(agentId);
+    const temporalExpired = await runPhase(
+      'temporal-validation',
+      () => this.phaseTemporalValidation(agentId),
+      { skippable: true },
+    );
 
     // Phase 5.7: Procedure Evolution — adjust confidence based on outcome history
-    const proceduresEvolved = await this.phaseProcedureEvolution(agentId);
+    const proceduresEvolved = await runPhase(
+      'procedure-evolution',
+      () => this.phaseProcedureEvolution(agentId),
+      { skippable: true },
+    );
 
     // Phase 5.9: Embedding Migration — re-embed rows whose embedding_model
     // differs from the current provider. Positioned before drift snapshot so
@@ -210,9 +294,15 @@ export class SleepCycleEngine {
     let embeddingsMigrated = 0;
     let embeddingsBacklog = 0;
     try {
-      const result = await this.phaseEmbeddingMigration(agentId);
-      embeddingsMigrated = result.migrated;
-      embeddingsBacklog = result.backlog;
+      embeddingsMigrated = await runPhase(
+        'embedding-migration',
+        async () => {
+          const result = await this.phaseEmbeddingMigration(agentId);
+          embeddingsBacklog = result.backlog;
+          return result.migrated;
+        },
+        { skippable: true },
+      );
     } catch (err) {
       log.error({ err, agentId }, 'embedding migration failed');
     }
@@ -223,7 +313,11 @@ export class SleepCycleEngine {
     // importance falls below evictionThreshold.
     let deprecatedDecayed = 0;
     try {
-      deprecatedDecayed = await this.phaseDeprecatedDecay(agentId);
+      deprecatedDecayed = await runPhase(
+        'deprecated-decay',
+        () => this.phaseDeprecatedDecay(agentId),
+        { skippable: true },
+      );
     } catch (err) {
       log.error({ err, agentId }, 'deprecated namespace decay failed');
     }
@@ -231,14 +325,19 @@ export class SleepCycleEngine {
     // Phase 5.12: Epistemic Promotion — promote/demote memories based on evidence
     let epistemicPromoted = 0;
     try {
-      epistemicPromoted = await this.phaseEpistemicPromotion(agentId);
+      epistemicPromoted = await runPhase('epistemic-promotion', () =>
+        this.phaseEpistemicPromotion(agentId),
+      );
     } catch (err) {
       log.error({ err, agentId }, 'epistemic promotion failed');
     }
 
     // Phase 5.8: Drift Snapshot — record drift signals for trend detection
     try {
-      await this.phaseDriftSnapshot(agentId, temporalExpired);
+      await runPhase('drift-snapshot', async () => {
+        await this.phaseDriftSnapshot(agentId, temporalExpired);
+        return 0;
+      });
     } catch (err) {
       log.error({ err, agentId }, 'drift snapshot failed');
     }
@@ -246,9 +345,12 @@ export class SleepCycleEngine {
     // Phase 6: Archive expired audit records
     let auditArchived = 0;
     if (this.audit) {
+      const audit = this.audit;
       try {
-        const archiveResult = await this.audit.archiveExpired(agentId);
-        auditArchived = archiveResult.archived + archiveResult.pruned;
+        auditArchived = await runPhase('audit-archive', async () => {
+          const archiveResult = await audit.archiveExpired(agentId);
+          return archiveResult.archived + archiveResult.pruned;
+        });
       } catch (err) {
         log.error({ err }, 'audit archive failed');
       }

--- a/tests/adaptive-sleep.test.ts
+++ b/tests/adaptive-sleep.test.ts
@@ -220,6 +220,21 @@ describe('shouldSkipPhase — skip logic', () => {
 });
 
 // ─── Integration tests — sleep cycle analytics ───────────────────────────────
+//
+// Skippable phases (per the wiring in src/sleep-cycle.ts run()) — these are
+// the cleanup / reflection tail that short-circuits when shouldSkipPhase()
+// returns true. The set must stay in sync with the {skippable: true} calls
+// in run().
+const SKIPPABLE_PHASES = [
+  'graph-maintenance',
+  'entity-dedup',
+  'reflection',
+  'schema-detection',
+  'temporal-validation',
+  'procedure-evolution',
+  'embedding-migration',
+  'deprecated-decay',
+] as const;
 
 describe('Adaptive Sleep Intelligence — integration', () => {
   before(async () => {
@@ -250,6 +265,111 @@ describe('Adaptive Sleep Intelligence — integration', () => {
     } finally {
       await pool.query(`DELETE FROM sleep_phase_analytics WHERE agent_id = $1`, [emptyAgent]);
       await pool.query(`DELETE FROM agents WHERE id = $1`, [emptyAgent]);
+    }
+  });
+
+  it('records one analytics row per phase that ran in a single cycle', async () => {
+    const agent = `${TEST_AGENT}-record-once`;
+    try {
+      await pool.query(`INSERT INTO agents (id) VALUES ($1) ON CONFLICT DO NOTHING`, [agent]);
+      await pool.query(`DELETE FROM sleep_phase_analytics WHERE agent_id = $1`, [agent]);
+
+      await engine.run(agent);
+
+      const { rows } = await pool.query<{ phase: string; count: string }>(
+        `SELECT phase, COUNT(*)::text AS count
+           FROM sleep_phase_analytics
+          WHERE agent_id = $1
+          GROUP BY phase`,
+        [agent],
+      );
+      assert.ok(rows.length > 0, 'at least one phase analytics row should be recorded');
+      for (const r of rows) {
+        assert.equal(
+          parseInt(r.count, 10),
+          1,
+          `phase ${r.phase} should record exactly one row per cycle, got ${r.count}`,
+        );
+      }
+
+      // Verify the core hot-path phases that always run are present.
+      const recorded = new Set(rows.map((r) => r.phase));
+      for (const required of ['weight-adaptation', 'scoring', 'triage', 'conflict-resolution']) {
+        assert.ok(
+          recorded.has(required),
+          `core phase ${required} must record an analytics row every cycle`,
+        );
+      }
+    } finally {
+      await pool.query(`DELETE FROM sleep_phase_analytics WHERE agent_id = $1`, [agent]);
+      await pool.query(`DELETE FROM agents WHERE id = $1`, [agent]);
+    }
+  });
+
+  it('skips skippable phases on subsequent cycles when prior runs were idle', async () => {
+    const agent = `${TEST_AGENT}-skip`;
+    try {
+      await pool.query(`INSERT INTO agents (id) VALUES ($1) ON CONFLICT DO NOTHING`, [agent]);
+      await pool.query(`DELETE FROM sleep_phase_analytics WHERE agent_id = $1`, [agent]);
+
+      // Seed 3 zero-change history rows for every skippable phase so
+      // shouldSkipPhase() returns true on the very next cycle. This avoids
+      // depending on the agent staying actually-idle through three full
+      // cycles (faster, deterministic).
+      for (const phase of SKIPPABLE_PHASES) {
+        for (let i = 0; i < 3; i++) {
+          await engine.recordPhaseAnalytics(agent, phase, 1, 0, 0);
+        }
+      }
+
+      // Snapshot counts before running the cycle.
+      const before = await pool.query<{ phase: string; count: string }>(
+        `SELECT phase, COUNT(*)::text AS count
+           FROM sleep_phase_analytics
+          WHERE agent_id = $1 AND phase = ANY($2::text[])
+          GROUP BY phase`,
+        [agent, SKIPPABLE_PHASES as unknown as string[]],
+      );
+      const beforeMap = new Map(before.rows.map((r) => [r.phase, parseInt(r.count, 10)]));
+
+      await engine.run(agent);
+
+      // After the cycle, skippable phases must NOT have a new row — a skip
+      // is silent (no analytics write) so the zero history persists.
+      const after = await pool.query<{ phase: string; count: string }>(
+        `SELECT phase, COUNT(*)::text AS count
+           FROM sleep_phase_analytics
+          WHERE agent_id = $1 AND phase = ANY($2::text[])
+          GROUP BY phase`,
+        [agent, SKIPPABLE_PHASES as unknown as string[]],
+      );
+      const afterMap = new Map(after.rows.map((r) => [r.phase, parseInt(r.count, 10)]));
+
+      for (const phase of SKIPPABLE_PHASES) {
+        const b = beforeMap.get(phase) ?? 0;
+        const a = afterMap.get(phase) ?? 0;
+        assert.equal(
+          a,
+          b,
+          `skippable phase ${phase} should not record a new row when skipped (before=${b}, after=${a})`,
+        );
+      }
+
+      // Sanity: a non-skippable core phase still records a row.
+      const { rows: scoringRows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count
+           FROM sleep_phase_analytics
+          WHERE agent_id = $1 AND phase = 'scoring'`,
+        [agent],
+      );
+      assert.equal(
+        parseInt(scoringRows[0]?.count ?? '0', 10),
+        1,
+        'non-skippable scoring phase should record a row even when skippable phases skip',
+      );
+    } finally {
+      await pool.query(`DELETE FROM sleep_phase_analytics WHERE agent_id = $1`, [agent]);
+      await pool.query(`DELETE FROM agents WHERE id = $1`, [agent]);
     }
   });
 });


### PR DESCRIPTION
## Summary

PR-A (#136) landed the `sleep_phase_analytics` table plus the
`recordPhaseAnalytics` / `shouldSkipPhase` helpers as analytics-only
infrastructure — the helpers were not yet called from
`SleepCycleEngine.run()`, so the table stayed empty. This PR wires them in.

- **Every top-level phase invocation in `run()` is wrapped with timing +
  `recordPhaseAnalytics()`** — one row per phase per cycle. Phase
  identifiers: `weight-adaptation`, `scoring`, `triage`,
  `capacity-eviction`, `conflict-resolution`, `revision`,
  `graph-maintenance`, `entity-dedup`, `reflection`, `cold-purge`,
  `schema-detection`, `temporal-validation`, `procedure-evolution`,
  `embedding-migration`, `deprecated-decay`, `epistemic-promotion`,
  `drift-snapshot`, `audit-archive`.
- **`shouldSkipPhase()` gating applied only to the cleanup / reflection
  tail** — `graph-maintenance`, `entity-dedup`, `reflection`,
  `schema-detection`, `temporal-validation`, `procedure-evolution`,
  `embedding-migration`, `deprecated-decay`. When the last three recorded
  runs of that phase had `changes_made = 0`, the phase short-circuits
  without I/O and without writing a fresh row (a write would re-anchor
  the zero history; the silent skip keeps the heuristic self-stable).
- **Core hot-path phases always run** — weight adaptation, scoring,
  triage, capacity eviction, conflict resolution, the Phase 3 revision
  loop, and Phase 6 audit archive are never skipped.
- **CHANGELOG.md** — the "Wiring deferred" note is replaced with a
  description of the wiring and phase-identifier list.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:adaptive-sleep` — 20/20 pass, including two new
      integration tests:
      - `records one analytics row per phase that ran in a single cycle`
      - `skips skippable phases on subsequent cycles when prior runs were idle`
- [x] `npm audit --omit=dev` — 0 vulnerabilities
- [ ] CI green