### PR TITLE
chore(ci): dependabot typescript ceiling + fix Build-job flake

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
+    # typescript is capped by the lint toolchain, not by us: every published
+    # @typescript-eslint release declares peer typescript ">=4.8.4 <6.1.0".
+    # A bump past that ceiling fails `npm ci` with ERESOLVE before any job can
+    # run, so it takes down every open PR, not just its own. Note this is a
+    # version ceiling rather than a semver-major ignore — 6.1.0 is a *minor*
+    # bump that would breach the same peer range. Lift when typescript-eslint
+    # widens the range.
+    ignore:
+      - dependency-name: "typescript"
+        versions: [">=6.1.0"]
     groups:
       production-dependencies:
         dependency-type: "production"

--- a/src/huggingface-transformers.d.ts
+++ b/src/huggingface-transformers.d.ts
@@ -1,0 +1,28 @@
+// Ambient declaration for the optional `@huggingface/transformers` dependency.
+//
+// Why this exists: `npm run build` is a plain `tsc`, but the only import of
+// this package (src/embedding.ts, LocalEmbeddingProvider.getPipeline) is a
+// dynamic import of an *optional* dependency. When an environment installs
+// without optional deps — which CI does intermittently, since the package
+// pulls platform-specific native artifacts — module resolution fails and the
+// build dies with TS2307 even though nothing about the source changed. That
+// made Build a coin-flip job rather than a signal.
+//
+// Declaring the module here decouples compilation from whether the optional
+// package happens to be on disk. The declaration is deliberately minimal: it
+// describes only the single factory the codebase calls, and returns `unknown`
+// because embedding.ts already defines its own `FeatureExtractionPipeline`
+// shape and casts to it. We therefore depend on none of the upstream types,
+// and shadowing them when the package *is* installed costs us nothing.
+
+declare module '@huggingface/transformers' {
+  /**
+   * Model factory. Returns the loaded pipeline as `unknown` — callers cast to
+   * the local structural type they actually rely on.
+   */
+  export function pipeline(
+    task: string,
+    model: string,
+    options?: { dtype?: string },
+  ): Promise<unknown>;
+}


### PR DESCRIPTION
## Summary

Gen 0 of the post-Phase-5 follow-ups — two independent CI-trust fixes, one commit each.

**1. `fix(build)`: declare the optional `@huggingface/transformers` module.** `npm run build` is a plain `tsc`, but `embedding.ts`'s only use of that package is a dynamic import of an *optional* dependency. Environments installing without optional deps (CI does so intermittently — the package pulls platform-specific native artifacts) fail resolution and die with `TS2307` on an unchanged tree. This is what failed on #168, and it makes Build a coin-flip rather than a signal.

The declaration is deliberately minimal — one factory returning `unknown`, since `embedding.ts` already defines its own `FeatureExtractionPipeline` shape and casts to it. No upstream type is depended on.

Verified all three states:
| State | Result |
|---|---|
| package present | build passes |
| package absent, with this declaration | build passes |
| package absent, without it (control) | `TS2307` at `embedding.ts:208` — reproduces the CI failure |

**2. `ci(deps)`: ignore `typescript >=6.1.0` in dependabot.** Every published `@typescript-eslint` release caps peer typescript at `<6.1.0`; a bump past it fails `npm ci` with ERESOLVE before any job runs, so it reds out *every* open PR. That cost the repo a day after #154, and open PR #169 is retrying it right now.

Expressed as a version ceiling, **not** `update-types: version-update:semver-major` — 6.1.0 is a *minor* bump that would breach the same peer range and slip past a major-only ignore. CI already catches this fast and loudly; the rule is about not burning CI minutes on unmergeable PRs, not a replacement for the gate.

## Follow-on dependabot housekeeping (after this merges)

- Close #169 — reverts the `~6.0.3` pin; all 11 jobs fail at `npm ci`.
- Merge #171 + #170 (typescript-eslint 8.65.0, both CLEAN) — merge both, since the plugin's peer wants parser ^8.65.0.
- Re-run #168's Build (it failed on the flake this PR fixes), then merge.
- Rebase #156 — not blocked, just stale; its last run predates the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xCqQo49d3CEbn6oEvb3Ru