### PR TITLE
feat(query): make the hybrid semantic weight configurable (default unchanged)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,7 @@ Key concepts: Hot → Warm → Cold tiers. Hybrid retrieval (FTS + pgvector HNSW
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `KEYWORD_OVERLAP_BOOST` | `0.3` | Score boost when query tokens overlap memory keywords |
+| `HYBRID_SEMANTIC_WEIGHT` | `1.5` | Weight on the semantic arm's RRF contribution in hybrid search. With RRF K=60, 1.5 means semantic ranks 1-31 outscore a keyword-only rank-1 hit; lower values give the lexical arm more say. Optimal value depends on the embedding model — measure before changing. |
 | `TEMPORAL_PROXIMITY_DAYS` | `7` | Days window for temporal proximity boost |
 | `CONSOLIDATION_INNER_BATCH_SIZE` | `50` | Hot-tier rows per inner consolidation batch |
 | `TEMPORAL_DECAY_RATE` | `0` | Score decay per hour (0 = disabled) |

--- a/src/memory-manager.ts
+++ b/src/memory-manager.ts
@@ -310,6 +310,7 @@ const DEFAULTS: MemForgeConfig = {
   temporalDecayRate: 0,
   consolidationInnerBatchSize: 50,
   keywordOverlapBoost: 0.3,
+  hybridSemanticWeight: 1.5,
   temporalProximityDays: 7,
   enableLlmRerank: false,
   enableLlmIngest: false,
@@ -1167,11 +1168,15 @@ Ranking (numbers only):`;
       }
     });
 
-    // Semantic results weighted 1.5x — paraphrase matching is the primary failure mode
-    // in conversational memory retrieval (users ask differently than memories are stored)
+    // Semantic arm weighted above 1.0 because paraphrase matching is the
+    // primary failure mode in conversational memory retrieval (users ask
+    // differently than memories are stored). The multiplier is configurable —
+    // at 1.5 with K=60, semantic ranks 1-31 outscore a keyword-only rank-1
+    // hit, which is a strong thumb on the scale and worth measuring.
+    const semanticWeight = this.config.hybridSemanticWeight ?? 1.5;
     semanticResults.forEach((row, idx) => {
       const key = String(row.id);
-      const rrf = 1.5 / (K + idx + 1);
+      const rrf = semanticWeight / (K + idx + 1);
       const existing = scores.get(key);
       if (existing) {
         existing.score += rrf;

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,6 +56,7 @@ const manager = new MemoryManager({
   temporalDecayRate: parseFloat(process.env['TEMPORAL_DECAY_RATE'] ?? '0'),
   consolidationInnerBatchSize: parseInt(process.env['CONSOLIDATION_INNER_BATCH_SIZE'] ?? '50', 10),
   keywordOverlapBoost: parseFloat(process.env['KEYWORD_OVERLAP_BOOST'] ?? '0.3'),
+  hybridSemanticWeight: parseFloat(process.env['HYBRID_SEMANTIC_WEIGHT'] ?? '1.5'),
   temporalProximityDays: parseFloat(process.env['TEMPORAL_PROXIMITY_DAYS'] ?? '7'),
   enableLlmRerank: process.env['ENABLE_LLM_RERANK'] === 'true',
   enableLlmIngest: process.env['ENABLE_LLM_INGEST'] === 'true',

--- a/src/types.ts
+++ b/src/types.ts
@@ -806,6 +806,15 @@ export interface MemForgeConfig {
   consolidationInnerBatchSize: number;
   /** Keyword overlap boost factor for hybrid search (default 0.3, 0 = disabled). */
   keywordOverlapBoost: number;
+  /**
+   * Weight applied to the semantic arm's RRF contribution in hybrid search
+   * (default 1.5). Above 1.0 the semantic ranking dominates: with the standard
+   * RRF constant K=60, a weight of 1.5 means semantic ranks 1-31 all outscore
+   * a keyword-only rank-1 hit, so lexical matches the vector arm missed are
+   * effectively invisible. Exposed as HYBRID_SEMANTIC_WEIGHT so the balance
+   * can be measured rather than assumed.
+   */
+  hybridSemanticWeight: number;
   /** Temporal proximity window in days for time-aware scoring (default 7, 0 = disabled). */
   temporalProximityDays: number;
   /** Enable LLM post-retrieval reranking (default false — opt-in, adds ~2K tokens/query) */


### PR DESCRIPTION
## What changed

The `1.5×` multiplier on the semantic arm's RRF contribution was a hardcoded constant with a large, undocumented effect: with RRF `K=60`, it means **semantic ranks 1–31 all outscore a keyword-only rank-1 hit** — lexical matches the vector arm missed are close to invisible. Now `HYBRID_SEMANTIC_WEIGHT`, documented in the config reference.

**The default is deliberately unchanged**, and that is the finding.

## The experiment, and why the answer is "leave it alone"

Pre-registered before running: sweep on a stratified 42-question sample (7 per category), then validate the winner on a **disjoint** 42-question sample selected the same way. Adopt only if it beats the 1.5 baseline on held-out R@5 without regressing R@1 by more than 2pp.

| weight | train R@5 | test R@5 | train R@1 | test R@1 |
|---|---|---|---|---|
| 0.75 | **95.2%** | 88.1% | **76.2%** | 76.2% |
| 1.50 (current) | 92.9% | 88.1% | 69.0% | **81.0%** |

On train, 0.75 looked clearly better across every k — the monotonic trend was tidy enough to be convincing, and any single-sample tuning would have adopted it. **It did not replicate.** On held-out data R@5 is identical and R@1 is 4.8pp *worse*.

Every metric flips direction between the two samples. That's the signature of sampling noise, not signal: at n=42 one question moves a metric 2.4pp, and the observed gaps are one to two questions.

So the pre-registered rule fails on both conditions, and the weight stays at 1.5.

## Why this is still worth merging

- The constant is now measurable per deployment. The optimum plausibly depends on the embedding model — this was measured with local `bge-small`, and a stronger embedder would likely shift it.
- The K=60 interaction is documented where someone changing it will see it.
- Resolving the question properly needs the full 500-question run, and the knob is what makes that a config change rather than a code change.

Gates: type-check, lint, integration 24, http 43, retrieval-determinism 3, causal-graph 39 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xCqQo49d3CEbn6oEvb3Ru